### PR TITLE
Remove useless cpubound joinall

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+tab_spaces = 2

--- a/httpsig-hyper/Cargo.toml
+++ b/httpsig-hyper/Cargo.toml
@@ -16,6 +16,7 @@ rust-version.workspace = true
 default = ["blocking", "digest-sha256", "digest-sha512"]
 digest-sha256 = []
 digest-sha512 = []
+ed25519-signature = ["httpsig/ed25519-signature"]
 blocking = ["futures/executor"]
 rsa-signature = ["httpsig/rsa-signature"]
 
@@ -47,6 +48,10 @@ bytes = { version = "1.11.1" }
 
 
 [dev-dependencies]
+httpsig-hyper = { path = ".", features = [
+  "digest-sha256",
+  "ed25519-signature",
+] }
 tokio = { version = "1.49.0", default-features = false, features = [
   "macros",
   "rt-multi-thread",
@@ -54,9 +59,9 @@ tokio = { version = "1.49.0", default-features = false, features = [
 
 [[example]]
 name = "hyper-response"
-required-features = ["digest-sha256"]
+required-features = ["digest-sha256", "ed25519-signature"]
 
 
 [[example]]
 name = "hyper-request"
-required-features = ["digest-sha256"]
+required-features = ["digest-sha256", "ed25519-signature"]

--- a/httpsig-hyper/Cargo.toml
+++ b/httpsig-hyper/Cargo.toml
@@ -17,6 +17,11 @@ default = ["blocking", "digest-sha256", "digest-sha512"]
 digest-sha256 = []
 digest-sha512 = []
 ed25519-signature = ["httpsig/ed25519-signature"]
+ecdsa-p256-sha256-signature = ["httpsig/ecdsa-p256-sha256-signature"]
+ecdsa-p384-sha384-signature = ["httpsig/ecdsa-p384-sha384-signature"]
+hmac-sha256-signature = ["httpsig/hmac-sha256-signature"]
+pem = ["httpsig/pem"]
+key-id = ["httpsig/key-id"]
 blocking = ["futures/executor"]
 rsa-signature = ["httpsig/rsa-signature"]
 
@@ -48,9 +53,12 @@ bytes = { version = "1.11.1" }
 
 
 [dev-dependencies]
-httpsig-hyper = { path = ".", features = [
-  "digest-sha256",
+httpsig = { path = "../httpsig", version = "0.0.24", features = [
   "ed25519-signature",
+  "ecdsa-p256-sha256-signature",
+  "hmac-sha256-signature",
+  "pem",
+  "key-id",
 ] }
 tokio = { version = "1.49.0", default-features = false, features = [
   "macros",
@@ -59,9 +67,20 @@ tokio = { version = "1.49.0", default-features = false, features = [
 
 [[example]]
 name = "hyper-response"
-required-features = ["digest-sha256", "ed25519-signature"]
+required-features = [
+  "digest-sha256",
+  "ed25519-signature",
+  "hmac-sha256-signature",
+  "pem",
+]
 
 
 [[example]]
 name = "hyper-request"
-required-features = ["digest-sha256", "ed25519-signature"]
+required-features = [
+  "digest-sha256",
+  "ed25519-signature",
+  "hmac-sha256-signature",
+  "pem",
+  "key-id",
+]

--- a/httpsig-hyper/Cargo.toml
+++ b/httpsig-hyper/Cargo.toml
@@ -13,7 +13,9 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["blocking"]
+default = ["blocking", "digest-sha256", "digest-sha512"]
+digest-sha256 = []
+digest-sha512 = []
 blocking = ["futures/executor"]
 rsa-signature = ["httpsig/rsa-signature"]
 
@@ -49,3 +51,12 @@ tokio = { version = "1.49.0", default-features = false, features = [
   "macros",
   "rt-multi-thread",
 ] } # testing only
+
+[[example]]
+name = "hyper-response"
+required-features = ["digest-sha256"]
+
+
+[[example]]
+name = "hyper-request"
+required-features = ["digest-sha256"]

--- a/httpsig-hyper/examples/hyper-request.rs
+++ b/httpsig-hyper/examples/hyper-request.rs
@@ -28,7 +28,10 @@ async fn build_request() -> Request<BoxBody> {
     .header("content-type", "application/json-patch+json")
     .body(body)
     .unwrap();
-  req.set_content_digest(&ContentDigestType::Sha256).await.unwrap()
+  req
+    .set_content_digest(&ContentDigestType::Sha256)
+    .await
+    .unwrap()
 }
 
 /// Sender function that generates a request with a signature
@@ -65,7 +68,8 @@ async fn sender_hs256(req: &mut Request<BoxBody>) {
   let mut signature_params = HttpSignatureParams::try_new(&covered_components).unwrap();
 
   // set signing/verifying key information, alg and keyid and random noce with hmac-sha256
-  let shared_key = SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
+  let shared_key =
+    SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
   signature_params.set_key_info(&shared_key);
   signature_params.set_random_nonce();
 
@@ -85,7 +89,9 @@ where
   let key_id = public_key.key_id();
 
   // verify signature with checking key_id
-  req.verify_message_signature(&public_key, Some(&key_id)).await
+  req
+    .verify_message_signature(&public_key, Some(&key_id))
+    .await
 }
 
 /// Receiver function that verifies a request with a signature of hmac-sha256
@@ -94,18 +100,24 @@ where
   B: http_body::Body + Send + Sync,
 {
   println!("Verifying HMAC-SHA256 signature");
-  let shared_key = SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
+  let shared_key =
+    SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
   let key_id = VerifyingKey::key_id(&shared_key);
 
   // verify signature with checking key_id
-  req.verify_message_signature(&shared_key, Some(&key_id)).await
+  req
+    .verify_message_signature(&shared_key, Some(&key_id))
+    .await
 }
 
 async fn scenario_multiple_signatures() {
   println!("--------------  Scenario: Multiple signatures  --------------");
 
   let mut request_from_sender = build_request().await;
-  println!("Request header before signing:\n{:#?}", request_from_sender.headers());
+  println!(
+    "Request header before signing:\n{:#?}",
+    request_from_sender.headers()
+  );
 
   // sender signs a signature of ed25519 and hmac-sha256
   sender_ed25519(&mut request_from_sender).await;
@@ -130,9 +142,15 @@ async fn scenario_multiple_signatures() {
     .map(|v| v.to_str())
     .collect::<Result<Vec<_>, _>>()
     .unwrap();
-  assert!(signature_inputs.iter().any(|v| v.starts_with(r##"siged25519=("##)));
-  assert!(signature_inputs.iter().any(|v| v.starts_with(r##"sighs256=("##)));
-  assert!(signatures.iter().any(|v| v.starts_with(r##"siged25519=:"##)));
+  assert!(signature_inputs
+    .iter()
+    .any(|v| v.starts_with(r##"siged25519=("##)));
+  assert!(signature_inputs
+    .iter()
+    .any(|v| v.starts_with(r##"sighs256=("##)));
+  assert!(signatures
+    .iter()
+    .any(|v| v.starts_with(r##"siged25519=:"##)));
   assert!(signatures.iter().any(|v| v.starts_with(r##"sighs256=:"##)));
 
   // receiver verifies the request with signatures
@@ -154,12 +172,18 @@ async fn scenario_single_signature_ed25519() {
   println!("--------------  Scenario: Single signature with Ed25519  --------------");
 
   let mut request_from_sender = build_request().await;
-  println!("Request header before signing:\n{:#?}", request_from_sender.headers());
+  println!(
+    "Request header before signing:\n{:#?}",
+    request_from_sender.headers()
+  );
 
   // sender signs a signature of ed25519
   sender_ed25519(&mut request_from_sender).await;
 
-  println!("Request header signed by ED25519:\n{:#?}", request_from_sender.headers());
+  println!(
+    "Request header signed by ED25519:\n{:#?}",
+    request_from_sender.headers()
+  );
 
   let signature_inputs = request_from_sender
     .headers()
@@ -175,8 +199,12 @@ async fn scenario_single_signature_ed25519() {
     .map(|v| v.to_str())
     .collect::<Result<Vec<_>, _>>()
     .unwrap();
-  assert!(signature_inputs.iter().any(|v| v.starts_with(r##"siged25519=("##)));
-  assert!(signatures.iter().any(|v| v.starts_with(r##"siged25519=:"##)));
+  assert!(signature_inputs
+    .iter()
+    .any(|v| v.starts_with(r##"siged25519=("##)));
+  assert!(signatures
+    .iter()
+    .any(|v| v.starts_with(r##"siged25519=:"##)));
 
   // receiver verifies the request with signatures
   // every signature is independent and verified separately

--- a/httpsig-hyper/src/error.rs
+++ b/httpsig-hyper/src/error.rs
@@ -27,13 +27,13 @@ pub enum HyperSigError {
 
   /// Invalid component param
   #[error("Invalid component param: {0}")]
-  InvalidComponentParam(String),
+  InvalidComponentParam(Cow<'static, str>),
 
   /// Invalid signature
   #[error("Invalid signature: {0}")]
   InvalidSignature(&'static str),
 
-  /// Inherited from HttpSigError
+  /// Inherited from [`HttpSigError`].
   #[error("HttpSigError: {0}")]
   HttpSigError(#[from] HttpSigError),
 }

--- a/httpsig-hyper/src/error.rs
+++ b/httpsig-hyper/src/error.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use httpsig::prelude::HttpSigError;
 use thiserror::Error;
 
@@ -9,7 +11,7 @@ pub type HyperSigResult<T> = std::result::Result<T, HyperSigError>;
 pub enum HyperSigError {
   /// No signature headers found
   #[error("No signature headers found: {0}")]
-  NoSignatureHeaders(String),
+  NoSignatureHeaders(&'static str),
 
   /// Failed to parse signature headers
   #[error("Failed to stringify signature headers: {0}")]
@@ -21,7 +23,7 @@ pub enum HyperSigError {
 
   /// Invalid component name
   #[error("Invalid component name: {0}")]
-  InvalidComponentName(String),
+  InvalidComponentName(Cow<'static, str>),
 
   /// Invalid component param
   #[error("Invalid component param: {0}")]
@@ -29,7 +31,7 @@ pub enum HyperSigError {
 
   /// Invalid signature
   #[error("Invalid signature: {0}")]
-  InvalidSignature(String),
+  InvalidSignature(&'static str),
 
   /// Inherited from HttpSigError
   #[error("HttpSigError: {0}")]

--- a/httpsig-hyper/src/hyper_content_digest.rs
+++ b/httpsig-hyper/src/hyper_content_digest.rs
@@ -44,12 +44,14 @@ pub trait ContentDigest: http_body::Body {
 /// Returns the digest of the given body in Vec<u8>
 fn derive_digest(body_bytes: &Bytes, cd_type: &ContentDigestType) -> Vec<u8> {
   match cd_type {
+    #[cfg(feature = "digest-sha256")]
     ContentDigestType::Sha256 => {
       let mut hasher = sha2::Sha256::new();
       hasher.update(body_bytes);
       hasher.finalize().to_vec()
     }
 
+    #[cfg(feature = "digest-sha512")]
     ContentDigestType::Sha512 => {
       let mut hasher = sha2::Sha512::new();
       hasher.update(body_bytes);
@@ -75,7 +77,9 @@ pub trait RequestContentDigest {
     Self: Sized;
 
   /// Verify the content digest in the request and returns self if it's valid otherwise returns error
-  fn verify_content_digest(self) -> impl Future<Output = Result<Self::PassthroughRequest, Self::Error>> + Send
+  fn verify_content_digest(
+    self,
+  ) -> impl Future<Output = Result<Self::PassthroughRequest, Self::Error>> + Send
   where
     Self: Sized;
 }
@@ -94,7 +98,9 @@ pub trait ResponseContentDigest {
     Self: Sized;
 
   /// Verify the content digest in the response and returns self if it's valid otherwise returns error
-  fn verify_content_digest(self) -> impl Future<Output = Result<Self::PassthroughResponse, Self::Error>> + Send
+  fn verify_content_digest(
+    self,
+  ) -> impl Future<Output = Result<Self::PassthroughResponse, Self::Error>> + Send
   where
     Self: Sized;
 }
@@ -108,7 +114,10 @@ where
   type PassthroughRequest = Request<BoxBody<Bytes, Self::Error>>;
 
   /// Set the content digest in the request
-  async fn set_content_digest(self, cd_type: &ContentDigestType) -> HyperDigestResult<Self::PassthroughRequest>
+  async fn set_content_digest(
+    self,
+    cd_type: &ContentDigestType,
+  ) -> HyperDigestResult<Self::PassthroughRequest>
   where
     Self: Sized,
   {
@@ -117,11 +126,14 @@ where
       .into_bytes_with_digest(cd_type)
       .await
       .map_err(|_e| HyperDigestError::HttpBodyError("Failed to generate digest".to_string()))?;
-    let new_body = Full::new(body_bytes).map_err(|never| match never {}).boxed();
+    let new_body = Full::new(body_bytes)
+      .map_err(|never| match never {})
+      .boxed();
 
-    parts
-      .headers
-      .insert(CONTENT_DIGEST_HEADER, format!("{cd_type}=:{digest}:").parse().unwrap());
+    parts.headers.insert(
+      CONTENT_DIGEST_HEADER,
+      format!("{cd_type}=:{digest}:").parse().unwrap(),
+    );
 
     let new_req = Request::from_parts(parts, new_body);
     Ok(new_req)
@@ -144,7 +156,9 @@ where
 
     // Use constant time equality check to prevent timing attacks
     if is_equal_digest(&digest, &expected_digest) {
-      let new_body = Full::new(body_bytes).map_err(|never| match never {}).boxed();
+      let new_body = Full::new(body_bytes)
+        .map_err(|never| match never {})
+        .boxed();
       let res = Request::from_parts(header, new_body);
       Ok(res)
     } else {
@@ -163,7 +177,10 @@ where
   type Error = HyperDigestError;
   type PassthroughResponse = Response<BoxBody<Bytes, Self::Error>>;
 
-  async fn set_content_digest(self, cd_type: &ContentDigestType) -> HyperDigestResult<Self::PassthroughResponse>
+  async fn set_content_digest(
+    self,
+    cd_type: &ContentDigestType,
+  ) -> HyperDigestResult<Self::PassthroughResponse>
   where
     Self: Sized,
   {
@@ -172,11 +189,14 @@ where
       .into_bytes_with_digest(cd_type)
       .await
       .map_err(|_e| HyperDigestError::HttpBodyError("Failed to generate digest".to_string()))?;
-    let new_body = Full::new(body_bytes).map_err(|never| match never {}).boxed();
+    let new_body = Full::new(body_bytes)
+      .map_err(|never| match never {})
+      .boxed();
 
-    parts
-      .headers
-      .insert(CONTENT_DIGEST_HEADER, format!("{cd_type}=:{digest}:").parse().unwrap());
+    parts.headers.insert(
+      CONTENT_DIGEST_HEADER,
+      format!("{cd_type}=:{digest}:").parse().unwrap(),
+    );
 
     let new_req = Response::from_parts(parts, new_body);
     Ok(new_req)
@@ -196,7 +216,9 @@ where
 
     // Use constant time equality check to prevent timing attacks
     if is_equal_digest(&digest, &expected_digest) {
-      let new_body = Full::new(body_bytes).map_err(|never| match never {}).boxed();
+      let new_body = Full::new(body_bytes)
+        .map_err(|never| match never {})
+        .boxed();
       let res = Response::from_parts(header, new_body);
       Ok(res)
     } else {
@@ -217,10 +239,14 @@ fn is_equal_digest(digest1: &[u8], digest2: &[u8]) -> bool {
   digest1.ct_eq(digest2).into()
 }
 
-async fn extract_content_digest(header_map: &http::HeaderMap) -> HyperDigestResult<(ContentDigestType, Vec<u8>)> {
+async fn extract_content_digest(
+  header_map: &http::HeaderMap,
+) -> HyperDigestResult<(ContentDigestType, Vec<u8>)> {
   let content_digest_header = header_map
     .get(CONTENT_DIGEST_HEADER)
-    .ok_or(HyperDigestError::NoDigestHeader("No content-digest header".to_string()))?
+    .ok_or(HyperDigestError::NoDigestHeader(
+      "No content-digest header".to_string(),
+    ))?
     .to_str()?;
   let indexmap = sfv::Parser::new(content_digest_header)
     .parse::<sfv::Dictionary>()
@@ -231,8 +257,9 @@ async fn extract_content_digest(header_map: &http::HeaderMap) -> HyperDigestResu
     ));
   };
   let (cd_type, cd) = indexmap.iter().next().unwrap();
-  let cd_type = ContentDigestType::from_str(cd_type.as_str())
-    .map_err(|e| HyperDigestError::InvalidHeaderValue(format!("Invalid Content-Digest type: {e}")))?;
+  let cd_type = ContentDigestType::from_str(cd_type.as_str()).map_err(|e| {
+    HyperDigestError::InvalidHeaderValue(format!("Invalid Content-Digest type: {e}"))
+  })?;
   if !matches!(
     cd,
     sfv::ListEntry::Item(sfv::Item {
@@ -263,17 +290,30 @@ mod tests {
   #[tokio::test]
   async fn content_digest() {
     let body = Full::new(&b"{\"hello\": \"world\"}"[..]);
-    let (_body_bytes, digest) = body.into_bytes_with_digest(&ContentDigestType::Sha256).await.unwrap();
+    #[cfg(feature = "digest-sha256")]
+    {
+      let (_body_bytes, digest) = body
+        .into_bytes_with_digest(&ContentDigestType::Sha256)
+        .await
+        .unwrap();
 
-    assert_eq!(digest, "X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=");
+      assert_eq!(digest, "X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=");
+    }
 
-    let (_body_bytes, digest) = body.into_bytes_with_digest(&ContentDigestType::Sha512).await.unwrap();
-    assert_eq!(
-      digest,
-      "WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew=="
-    );
+    #[cfg(feature = "digest-sha512")]
+    {
+      let (_body_bytes, digest) = body
+        .into_bytes_with_digest(&ContentDigestType::Sha512)
+        .await
+        .unwrap();
+      assert_eq!(
+        digest,
+        "WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew=="
+      );
+    }
   }
 
+  #[cfg(feature = "digest-sha256")]
   #[tokio::test]
   async fn hyper_request_test() {
     let body = Full::new(&b"{\"hello\": \"world\"}"[..]);
@@ -285,16 +325,28 @@ mod tests {
       .header("content-type", "application/json")
       .body(body)
       .unwrap();
-    let req = req.set_content_digest(&ContentDigestType::Sha256).await.unwrap();
+    let req = req
+      .set_content_digest(&ContentDigestType::Sha256)
+      .await
+      .unwrap();
 
     assert!(req.headers().contains_key(CONTENT_DIGEST_HEADER));
-    let digest = req.headers().get(CONTENT_DIGEST_HEADER).unwrap().to_str().unwrap();
-    assert_eq!(digest, format!("sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:"));
+    let digest = req
+      .headers()
+      .get(CONTENT_DIGEST_HEADER)
+      .unwrap()
+      .to_str()
+      .unwrap();
+    assert_eq!(
+      digest,
+      format!("sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:")
+    );
 
     let verified = req.verify_content_digest().await;
     assert!(verified.is_ok());
   }
 
+  #[cfg(feature = "digest-sha256")]
   #[tokio::test]
   async fn hyper_response_test() {
     let body = Full::new(&b"{\"hello\": \"world\"}"[..]);
@@ -305,16 +357,28 @@ mod tests {
       .header("content-type", "application/json")
       .body(body)
       .unwrap();
-    let res = res.set_content_digest(&ContentDigestType::Sha256).await.unwrap();
+    let res = res
+      .set_content_digest(&ContentDigestType::Sha256)
+      .await
+      .unwrap();
 
     assert!(res.headers().contains_key(CONTENT_DIGEST_HEADER));
-    let digest = res.headers().get(CONTENT_DIGEST_HEADER).unwrap().to_str().unwrap();
-    assert_eq!(digest, format!("sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:"));
+    let digest = res
+      .headers()
+      .get(CONTENT_DIGEST_HEADER)
+      .unwrap()
+      .to_str()
+      .unwrap();
+    assert_eq!(
+      digest,
+      format!("sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:")
+    );
 
     let verified = res.verify_content_digest().await;
     assert!(verified.is_ok());
   }
 
+  #[cfg(feature = "digest-sha256")]
   #[tokio::test]
   async fn hyper_request_digest_mismatch_by_body_tamper_should_fail() {
     // 1) Create a request and set a correct Content-Digest for the original body
@@ -327,7 +391,10 @@ mod tests {
       .body(body)
       .unwrap();
 
-    let req = req.set_content_digest(&ContentDigestType::Sha256).await.unwrap();
+    let req = req
+      .set_content_digest(&ContentDigestType::Sha256)
+      .await
+      .unwrap();
     assert!(req.headers().contains_key(CONTENT_DIGEST_HEADER));
 
     // 2) Tamper the body while keeping the digest header unchanged
@@ -344,6 +411,7 @@ mod tests {
     }
   }
 
+  #[cfg(feature = "digest-sha256")]
   #[tokio::test]
   async fn hyper_response_digest_mismatch_by_header_tamper_should_fail() {
     // 1) Create a response and set a correct Content-Digest
@@ -355,7 +423,10 @@ mod tests {
       .body(body)
       .unwrap();
 
-    let res = res.set_content_digest(&ContentDigestType::Sha256).await.unwrap();
+    let res = res
+      .set_content_digest(&ContentDigestType::Sha256)
+      .await
+      .unwrap();
     let (mut parts, body) = res.into_parts();
 
     // 2) Tamper the Content-Digest header (keep it syntactically valid)
@@ -363,7 +434,9 @@ mod tests {
     // Change the first character to another valid base64 character.
     parts.headers.insert(
       CONTENT_DIGEST_HEADER,
-      "sha-256=:Y48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:".parse().unwrap(),
+      "sha-256=:Y48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:"
+        .parse()
+        .unwrap(),
     );
 
     let tampered_res = Response::from_parts(parts, body);
@@ -397,6 +470,7 @@ mod tests {
     }
   }
 
+  #[cfg(feature = "digest-sha256")]
   #[tokio::test]
   async fn hyper_request_digest_length_mismatch_should_fail() {
     // 1) Create a request and attach a valid Content-Digest header
@@ -409,7 +483,10 @@ mod tests {
       .body(body)
       .unwrap();
 
-    let req = req.set_content_digest(&ContentDigestType::Sha256).await.unwrap();
+    let req = req
+      .set_content_digest(&ContentDigestType::Sha256)
+      .await
+      .unwrap();
 
     // 2) Extract parts and replace the Content-Digest header
     //    with a syntactically valid but length-mismatched base64 value.

--- a/httpsig-hyper/src/hyper_http.rs
+++ b/httpsig-hyper/src/hyper_http.rs
@@ -1049,6 +1049,6 @@ fn extract_http_message_component<M: HttpMessage>(
 }
 
 /* --------------------------------------- */
-#[cfg(all(test, feature = "digest-sha256"))]
+#[cfg(test)]
 #[path = "hyper_http_tests.rs"]
 mod tests;

--- a/httpsig-hyper/src/hyper_http.rs
+++ b/httpsig-hyper/src/hyper_http.rs
@@ -3,9 +3,11 @@ use http::{HeaderMap, Request, Response};
 use http_body::Body;
 use httpsig::prelude::{
   message_component::{
-    DerivedComponentName, HttpMessageComponent, HttpMessageComponentId, HttpMessageComponentName, HttpMessageComponentParam,
+    DerivedComponentName, HttpMessageComponent, HttpMessageComponentId, HttpMessageComponentName,
+    HttpMessageComponentParam,
   },
-  AlgorithmName, HttpSignatureBase, HttpSignatureHeaders, HttpSignatureHeadersMap, HttpSignatureParams, SigningKey, VerifyingKey,
+  AlgorithmName, HttpSignatureBase, HttpSignatureHeaders, HttpSignatureHeadersMap,
+  HttpSignatureParams, SigningKey, VerifyingKey,
 };
 use indexmap::{IndexMap, IndexSet};
 use std::{future::Future, str::FromStr};
@@ -24,10 +26,14 @@ pub trait MessageSignature {
   fn has_message_signature(&self) -> bool;
 
   /// Extract all key ids for signature bases contained in the request headers
-  fn get_alg_key_ids(&self) -> Result<IndexMap<SignatureName, (Option<AlgorithmName>, Option<KeyId>)>, Self::Error>;
+  fn get_alg_key_ids(
+    &self,
+  ) -> Result<IndexMap<SignatureName, (Option<AlgorithmName>, Option<KeyId>)>, Self::Error>;
 
   /// Extract all signature params used to generate signature bases contained in the request headers
-  fn get_signature_params(&self) -> Result<IndexMap<SignatureName, HttpSignatureParams>, Self::Error>;
+  fn get_signature_params(
+    &self,
+  ) -> Result<IndexMap<SignatureName, HttpSignatureParams>, Self::Error>;
 }
 
 /// A trait about http message signature for request
@@ -73,7 +79,9 @@ pub trait MessageSignatureReq {
     T: VerifyingKey + Sync;
 
   /// Extract all signature bases contained in the request headers
-  fn extract_signatures(&self) -> Result<IndexMap<SignatureName, (HttpSignatureBase, HttpSignatureHeaders)>, Self::Error>;
+  fn extract_signatures(
+    &self,
+  ) -> Result<IndexMap<SignatureName, (HttpSignatureBase, HttpSignatureHeaders)>, Self::Error>;
 }
 
 /// A trait about http message signature for response
@@ -162,7 +170,11 @@ pub trait MessageSignatureReqSync: MessageSignatureReq {
     Self: Sized,
     T: SigningKey + Sync;
 
-  fn verify_message_signature_sync<T>(&self, verifying_key: &T, key_id: Option<&str>) -> Result<SignatureName, Self::Error>
+  fn verify_message_signature_sync<T>(
+    &self,
+    verifying_key: &T,
+    key_id: Option<&str>,
+  ) -> Result<SignatureName, Self::Error>
   where
     Self: Sized,
     T: VerifyingKey + Sync;
@@ -243,13 +255,17 @@ where
   }
 
   /// Extract all signature bases contained in the request headers
-  fn get_alg_key_ids(&self) -> HyperSigResult<IndexMap<SignatureName, (Option<AlgorithmName>, Option<KeyId>)>> {
+  fn get_alg_key_ids(
+    &self,
+  ) -> HyperSigResult<IndexMap<SignatureName, (Option<AlgorithmName>, Option<KeyId>)>> {
     let req_or_res = RequestOrResponse::Request(self);
     get_alg_key_ids_inner(&req_or_res)
   }
 
   /// Extract all signature params used to generate signature bases contained in the request headers
-  fn get_signature_params(&self) -> Result<IndexMap<SignatureName, HttpSignatureParams>, Self::Error> {
+  fn get_signature_params(
+    &self,
+  ) -> Result<IndexMap<SignatureName, HttpSignatureParams>, Self::Error> {
     let req_or_res = RequestOrResponse::Request(self);
     get_signature_params_inner(&req_or_res)
   }
@@ -289,7 +305,8 @@ where
     let vec_signature_bases = params_key_name
       .iter()
       .map(|(params, key, name)| {
-        build_signature_base(&req_or_res, params, None as Option<&Request<()>>).map(|base| (base, *key, *name))
+        build_signature_base(&req_or_res, params, None as Option<&Request<()>>)
+          .map(|base| (base, *key, *name))
       })
       .collect::<Result<Vec<_>, _>>()?;
     let vec_signature_headers = futures::future::join_all(
@@ -301,9 +318,10 @@ where
     .into_iter()
     .collect::<Result<Vec<_>, _>>()?;
     vec_signature_headers.iter().try_for_each(|headers| {
-      self
-        .headers_mut()
-        .append("signature-input", headers.signature_input_header_value().parse()?);
+      self.headers_mut().append(
+        "signature-input",
+        headers.signature_input_header_value().parse()?,
+      );
       self
         .headers_mut()
         .append("signature", headers.signature_header_value().parse()?);
@@ -315,7 +333,11 @@ where
   /// Return Ok(()) if the signature is valid.
   /// If invalid for the given key or error occurs (like the case where the request does not have signature and/or signature-input headers), return Err.
   /// If key_id is given, it is used to match the key id in signature params
-  async fn verify_message_signature<T>(&self, verifying_key: &T, key_id: Option<&str>) -> HyperSigResult<SignatureName>
+  async fn verify_message_signature<T>(
+    &self,
+    verifying_key: &T,
+    key_id: Option<&str>,
+  ) -> HyperSigResult<SignatureName>
   where
     Self: Sized,
     T: VerifyingKey + Sync,
@@ -345,7 +367,9 @@ where
   }
 
   /// Extract all signature bases contained in the request headers
-  fn extract_signatures(&self) -> Result<IndexMap<SignatureName, (HttpSignatureBase, HttpSignatureHeaders)>, Self::Error> {
+  fn extract_signatures(
+    &self,
+  ) -> Result<IndexMap<SignatureName, (HttpSignatureBase, HttpSignatureHeaders)>, Self::Error> {
     let req_or_res = RequestOrResponse::Request(self);
     extract_signatures_inner(&req_or_res, None as Option<&Request<()>>)
   }
@@ -364,13 +388,17 @@ where
   }
 
   /// Extract all key ids for signature bases contained in the response headers
-  fn get_alg_key_ids(&self) -> Result<IndexMap<SignatureName, (Option<AlgorithmName>, Option<KeyId>)>, Self::Error> {
+  fn get_alg_key_ids(
+    &self,
+  ) -> Result<IndexMap<SignatureName, (Option<AlgorithmName>, Option<KeyId>)>, Self::Error> {
     let req_or_res = RequestOrResponse::Response(self);
     get_alg_key_ids_inner(&req_or_res)
   }
 
   /// Extract all signature params used to generate signature bases contained in the response headers
-  fn get_signature_params(&self) -> Result<IndexMap<SignatureName, HttpSignatureParams>, Self::Error> {
+  fn get_signature_params(
+    &self,
+  ) -> Result<IndexMap<SignatureName, HttpSignatureParams>, Self::Error> {
     let req_or_res = RequestOrResponse::Response(self);
     get_signature_params_inner(&req_or_res)
   }
@@ -396,7 +424,10 @@ where
     B: Sync,
   {
     self
-      .set_message_signatures(&[(signature_params, signing_key, signature_name)], req_for_param)
+      .set_message_signatures(
+        &[(signature_params, signing_key, signature_name)],
+        req_for_param,
+      )
       .await
   }
 
@@ -413,7 +444,9 @@ where
 
     let vec_signature_bases = params_key_name
       .iter()
-      .map(|(params, key, name)| build_signature_base(&req_or_res, params, req_for_param).map(|base| (base, *key, *name)))
+      .map(|(params, key, name)| {
+        build_signature_base(&req_or_res, params, req_for_param).map(|base| (base, *key, *name))
+      })
       .collect::<Result<Vec<_>, _>>()?;
     let vec_signature_headers = futures::future::join_all(
       vec_signature_bases
@@ -425,9 +458,10 @@ where
     .collect::<Result<Vec<_>, _>>()?;
 
     vec_signature_headers.iter().try_for_each(|headers| {
-      self
-        .headers_mut()
-        .append("signature-input", headers.signature_input_header_value().parse()?);
+      self.headers_mut().append(
+        "signature-input",
+        headers.signature_input_header_value().parse()?,
+      );
       self
         .headers_mut()
         .append("signature", headers.signature_header_value().parse()?);
@@ -501,7 +535,11 @@ where
     Self: Sized,
     T: SigningKey + Sync,
   {
-    futures::executor::block_on(self.set_message_signature(signature_params, signing_key, signature_name))
+    futures::executor::block_on(self.set_message_signature(
+      signature_params,
+      signing_key,
+      signature_name,
+    ))
   }
 
   fn set_message_signatures_sync<T>(
@@ -515,7 +553,11 @@ where
     futures::executor::block_on(self.set_message_signatures(params_key_name))
   }
 
-  fn verify_message_signature_sync<T>(&self, verifying_key: &T, key_id: Option<&str>) -> Result<SignatureName, Self::Error>
+  fn verify_message_signature_sync<T>(
+    &self,
+    verifying_key: &T,
+    key_id: Option<&str>,
+  ) -> Result<SignatureName, Self::Error>
   where
     Self: Sized,
     T: VerifyingKey + Sync,
@@ -552,7 +594,12 @@ where
     T: SigningKey + Sync,
     B: Sync,
   {
-    futures::executor::block_on(self.set_message_signature(signature_params, signing_key, signature_name, req_for_param))
+    futures::executor::block_on(self.set_message_signature(
+      signature_params,
+      signing_key,
+      signature_name,
+      req_for_param,
+    ))
   }
 
   fn set_message_signatures_sync<T, B>(
@@ -685,7 +732,12 @@ where
       // check if any one of the signature headers is valid
       let successful_sig_names = filtered
         .iter()
-        .filter_map(|(&name, (base, headers))| base.verify_signature_headers(*key, headers).ok().map(|_| name.clone()))
+        .filter_map(|(&name, (base, headers))| {
+          base
+            .verify_signature_headers(*key, headers)
+            .ok()
+            .map(|_| name.clone())
+        })
         .collect::<IndexSet<_>>();
       if !successful_sig_names.is_empty() {
         Ok(successful_sig_names.first().unwrap().clone())
@@ -721,7 +773,9 @@ impl<B> RequestOrResponse<'_, B> {
   fn uri(&self) -> HyperSigResult<&http::Uri> {
     match self {
       RequestOrResponse::Request(req) => Ok(req.uri()),
-      _ => Err(HyperSigError::InvalidComponentName("`uri` is only for request".to_string())),
+      _ => Err(HyperSigError::InvalidComponentName(
+        "`uri` is only for request".to_string(),
+      )),
     }
   }
 
@@ -743,7 +797,9 @@ impl<B> RequestOrResponse<'_, B> {
 }
 
 /// Extract signature and signature-input with signature-name indication from http request and response
-fn extract_signature_headers_with_name<B>(req_or_res: &RequestOrResponse<B>) -> HyperSigResult<HttpSignatureHeadersMap> {
+fn extract_signature_headers_with_name<B>(
+  req_or_res: &RequestOrResponse<B>,
+) -> HyperSigResult<HttpSignatureHeadersMap> {
   let headers = req_or_res.headers();
   if !(headers.contains_key("signature-input") && headers.contains_key("signature")) {
     return Err(HyperSigError::NoSignatureHeaders(
@@ -764,7 +820,8 @@ fn extract_signature_headers_with_name<B>(req_or_res: &RequestOrResponse<B>) -> 
     .collect::<Result<Vec<_>, _>>()?
     .join(", ");
 
-  let signature_headers = HttpSignatureHeaders::try_parse(&signature_strings, &signature_input_strings)?;
+  let signature_headers =
+    HttpSignatureHeaders::try_parse(&signature_strings, &signature_input_strings)?;
   Ok(signature_headers)
 }
 
@@ -781,7 +838,11 @@ fn build_signature_base<B1, B2>(
     .covered_components
     .iter()
     .map(|component_id| {
-      if component_id.params.0.contains(&HttpMessageComponentParam::Req) {
+      if component_id
+        .params
+        .0
+        .contains(&HttpMessageComponentParam::Req)
+      {
         if matches!(req_or_res, RequestOrResponse::Request(_)) {
           return Err(HyperSigError::InvalidComponentParam(
             "`req` is not allowed in request".to_string(),
@@ -804,7 +865,10 @@ fn build_signature_base<B1, B2>(
 }
 
 /// Extract http field from hyper http request/response
-fn extract_http_field<B>(req_or_res: &RequestOrResponse<B>, id: &HttpMessageComponentId) -> HyperSigResult<HttpMessageComponent> {
+fn extract_http_field<B>(
+  req_or_res: &RequestOrResponse<B>,
+  id: &HttpMessageComponentId,
+) -> HyperSigResult<HttpMessageComponent> {
   let HttpMessageComponentName::HttpField(header_name) = &id.name else {
     return Err(HyperSigError::InvalidComponentName(
       "invalid http message component name as http field".to_string(),
@@ -839,7 +903,11 @@ fn extract_derived_component<B>(
   // - `req`: only valid on response messages (to reference request-derived components, §2.4)
   // - `sf`, `key`, `bs`, `tr`: only valid on HTTP field components, not derived components
   id.params.0.iter().try_for_each(|param| match param {
-    HttpMessageComponentParam::Name(_) if matches!(derived_id, DerivedComponentName::QueryParam) => Ok(()),
+    HttpMessageComponentParam::Name(_)
+      if matches!(derived_id, DerivedComponentName::QueryParam) =>
+    {
+      Ok(())
+    }
     HttpMessageComponentParam::Name(_) => Err(HyperSigError::InvalidComponentParam(
       "`name` parameter is only allowed for `@query-param`".to_string(),
     )),
@@ -889,10 +957,18 @@ fn extract_derived_component<B>(
   let field_values: Vec<String> = match derived_id {
     DerivedComponentName::Method => vec![req_or_res.method()?.as_str().to_string()],
     DerivedComponentName::TargetUri => vec![req_or_res.uri()?.to_string()],
-    DerivedComponentName::Authority => vec![req_or_res.uri()?.authority().map(|s| s.to_string()).unwrap_or("".to_string())],
+    DerivedComponentName::Authority => vec![req_or_res
+      .uri()?
+      .authority()
+      .map(|s| s.to_string())
+      .unwrap_or("".to_string())],
     DerivedComponentName::Scheme => vec![req_or_res.uri()?.scheme_str().unwrap_or("").to_string()],
     DerivedComponentName::RequestTarget => match *req_or_res.method()? {
-      http::Method::CONNECT => vec![req_or_res.uri()?.authority().map(|s| s.to_string()).unwrap_or("".to_string())],
+      http::Method::CONNECT => vec![req_or_res
+        .uri()?
+        .authority()
+        .map(|s| s.to_string())
+        .unwrap_or("".to_string())],
       http::Method::OPTIONS => vec!["*".to_string()],
       _ => vec![req_or_res
         .uri()?
@@ -908,7 +984,11 @@ fn extract_derived_component<B>(
         p.to_string()
       }
     }],
-    DerivedComponentName::Query => vec![req_or_res.uri()?.query().map(|v| format!("?{v}")).unwrap_or("?".to_string())],
+    DerivedComponentName::Query => vec![req_or_res
+      .uri()?
+      .query()
+      .map(|v| format!("?{v}"))
+      .unwrap_or("?".to_string())],
     DerivedComponentName::QueryParam => {
       let query = req_or_res.uri()?.query().unwrap_or("");
       query
@@ -937,11 +1017,13 @@ fn extract_http_message_component<B>(
 ) -> HyperSigResult<HttpMessageComponent> {
   match &target_component_id.name {
     HttpMessageComponentName::HttpField(_) => extract_http_field(req_or_res, target_component_id),
-    HttpMessageComponentName::Derived(_) => extract_derived_component(req_or_res, target_component_id),
+    HttpMessageComponentName::Derived(_) => {
+      extract_derived_component(req_or_res, target_component_id)
+    }
   }
 }
 
 /* --------------------------------------- */
-#[cfg(test)]
+#[cfg(all(test, feature = "digest-sha256"))]
 #[path = "hyper_http_tests.rs"]
 mod tests;

--- a/httpsig-hyper/src/hyper_http.rs
+++ b/httpsig-hyper/src/hyper_http.rs
@@ -10,7 +10,7 @@ use httpsig::prelude::{
   HttpSignatureParams, SigningKey, VerifyingKey,
 };
 use indexmap::{IndexMap, IndexSet};
-use std::{future::Future, str::FromStr};
+use std::{borrow::Cow, future::Future, str::FromStr};
 
 /// A type alias for the signature name
 type SignatureName = String;
@@ -833,7 +833,7 @@ impl<B> HttpMessage for Response<B> {
       // `@status` must not have `req` parameter
       if matches!(derived_name, DerivedComponentName::Status) {
         Err(HyperSigError::InvalidComponentParam(
-          "`@status` does not accept `req` parameter".to_string(),
+          "`@status` does not accept `req` parameter".into(),
         ))
       } else {
         Ok(())
@@ -957,17 +957,20 @@ fn extract_derived_component<M: HttpMessage>(
       Ok(())
     }
     HttpMessageComponentParam::Name(_) => Err(HyperSigError::InvalidComponentParam(
-      "`name` parameter is only allowed for `@query-param`".to_string(),
+      "`name` parameter is only allowed for `@query-param`".into(),
     )),
     // `req` is only meaningful in response signatures (RFC 9421 §2.4).
     // `build_signature_base` already validates this and re-dispatches extraction against the
     // original request, so `req_or_res` here should always be `Request`.
     // Guard against misuse by callers that bypass `build_signature_base`.
     HttpMessageComponentParam::Req => req_or_res.on_message_derived_component_req_param(),
-    _ => Err(HyperSigError::InvalidComponentParam(format!(
-      "parameter `{}` is not allowed on derived components",
-      String::from(param.clone())
-    ))),
+    _ => Err(HyperSigError::InvalidComponentParam(
+      format!(
+        "parameter `{}` is not allowed on derived components",
+        Cow::from(param)
+      )
+      .into(),
+    )),
   })?;
 
   req_or_res.on_message_derived_component(derived_name, id)?;

--- a/httpsig-hyper/src/hyper_http.rs
+++ b/httpsig-hyper/src/hyper_http.rs
@@ -258,18 +258,18 @@ where
   fn get_alg_key_ids(
     &self,
   ) -> HyperSigResult<IndexMap<SignatureName, (Option<AlgorithmName>, Option<KeyId>)>> {
-    let req_or_res = RequestOrResponse::Request(self);
-    get_alg_key_ids_inner(&req_or_res)
+    get_alg_key_ids_inner(self)
   }
 
   /// Extract all signature params used to generate signature bases contained in the request headers
   fn get_signature_params(
     &self,
   ) -> Result<IndexMap<SignatureName, HttpSignatureParams>, Self::Error> {
-    let req_or_res = RequestOrResponse::Request(self);
-    get_signature_params_inner(&req_or_res)
+    get_signature_params_inner(self)
   }
 }
+
+const NO_REQ_FOR_PARAM: Option<&Request<()>> = None;
 
 impl<D> MessageSignatureReq for Request<D>
 where
@@ -301,23 +301,9 @@ where
     Self: Sized,
     T: SigningKey + Sync,
   {
-    let req_or_res = RequestOrResponse::Request(self);
-    let vec_signature_bases = params_key_name
-      .iter()
-      .map(|(params, key, name)| {
-        build_signature_base(&req_or_res, params, None as Option<&Request<()>>)
-          .map(|base| (base, *key, *name))
-      })
-      .collect::<Result<Vec<_>, _>>()?;
-    let vec_signature_headers = futures::future::join_all(
-      vec_signature_bases
-        .into_iter()
-        .map(|(base, key, name)| async move { base.build_signature_headers(key, name) }),
-    )
-    .await
-    .into_iter()
-    .collect::<Result<Vec<_>, _>>()?;
-    vec_signature_headers.iter().try_for_each(|headers| {
+    for (params, key, name) in params_key_name {
+      let base = build_signature_base(self, params, NO_REQ_FOR_PARAM)?;
+      let headers = base.build_signature_headers(*key, *name)?;
       self.headers_mut().append(
         "signature-input",
         headers.signature_input_header_value().parse()?,
@@ -325,8 +311,8 @@ where
       self
         .headers_mut()
         .append("signature", headers.signature_header_value().parse()?);
-      Ok(()) as Result<(), HyperSigError>
-    })
+    }
+    Ok(())
   }
 
   /// Verify the http message signature with given verifying key if the request has signature and signature-input headers
@@ -359,19 +345,18 @@ where
   {
     if !self.has_message_signature() {
       return Err(HyperSigError::NoSignatureHeaders(
-        "The request does not have signature and signature-input headers".to_string(),
+        "The request does not have signature and signature-input headers",
       ));
     }
     let map_signature_with_base = self.extract_signatures()?;
-    verify_message_signatures_inner(&map_signature_with_base, key_and_id).await
+    Ok(verify_message_signatures_inner(&map_signature_with_base, key_and_id).await)
   }
 
   /// Extract all signature bases contained in the request headers
   fn extract_signatures(
     &self,
   ) -> Result<IndexMap<SignatureName, (HttpSignatureBase, HttpSignatureHeaders)>, Self::Error> {
-    let req_or_res = RequestOrResponse::Request(self);
-    extract_signatures_inner(&req_or_res, None as Option<&Request<()>>)
+    extract_signatures_inner(self, None as Option<&Request<()>>)
   }
 }
 
@@ -391,16 +376,14 @@ where
   fn get_alg_key_ids(
     &self,
   ) -> Result<IndexMap<SignatureName, (Option<AlgorithmName>, Option<KeyId>)>, Self::Error> {
-    let req_or_res = RequestOrResponse::Response(self);
-    get_alg_key_ids_inner(&req_or_res)
+    get_alg_key_ids_inner(self)
   }
 
   /// Extract all signature params used to generate signature bases contained in the response headers
   fn get_signature_params(
     &self,
   ) -> Result<IndexMap<SignatureName, HttpSignatureParams>, Self::Error> {
-    let req_or_res = RequestOrResponse::Response(self);
-    get_signature_params_inner(&req_or_res)
+    get_signature_params_inner(self)
   }
 }
 
@@ -440,24 +423,9 @@ where
     Self: Sized,
     T: SigningKey + Sync,
   {
-    let req_or_res = RequestOrResponse::Response(self);
-
-    let vec_signature_bases = params_key_name
-      .iter()
-      .map(|(params, key, name)| {
-        build_signature_base(&req_or_res, params, req_for_param).map(|base| (base, *key, *name))
-      })
-      .collect::<Result<Vec<_>, _>>()?;
-    let vec_signature_headers = futures::future::join_all(
-      vec_signature_bases
-        .into_iter()
-        .map(|(base, key, name)| async move { base.build_signature_headers(key, name) }),
-    )
-    .await
-    .into_iter()
-    .collect::<Result<Vec<_>, _>>()?;
-
-    vec_signature_headers.iter().try_for_each(|headers| {
+    for (params, key, name) in params_key_name {
+      let base = build_signature_base(self, params, req_for_param)?;
+      let headers = base.build_signature_headers(*key, *name)?;
       self.headers_mut().append(
         "signature-input",
         headers.signature_input_header_value().parse()?,
@@ -465,8 +433,9 @@ where
       self
         .headers_mut()
         .append("signature", headers.signature_header_value().parse()?);
-      Ok(()) as Result<(), HyperSigError>
-    })
+    }
+
+    Ok(())
   }
 
   /// Verify the http message signature with given verifying key if the response has signature and signature-input headers
@@ -502,11 +471,11 @@ where
   {
     if !self.has_message_signature() {
       return Err(HyperSigError::NoSignatureHeaders(
-        "The response does not have signature and signature-input headers".to_string(),
+        "The response does not have signature and signature-input headers",
       ));
     }
     let map_signature_with_base = self.extract_signatures(req_for_param)?;
-    verify_message_signatures_inner(&map_signature_with_base, key_and_id).await
+    Ok(verify_message_signatures_inner(&map_signature_with_base, key_and_id).await)
   }
 
   /// Extract all signature bases contained in the response headers
@@ -514,8 +483,7 @@ where
     &self,
     req_for_param: Option<&Request<B>>,
   ) -> Result<IndexMap<SignatureName, (HttpSignatureBase, HttpSignatureHeaders)>, Self::Error> {
-    let req_or_res = RequestOrResponse::Response(self);
-    extract_signatures_inner(&req_or_res, req_for_param)
+    extract_signatures_inner(self, req_for_param)
   }
 }
 
@@ -651,8 +619,8 @@ fn has_message_signature_inner(headers: &HeaderMap) -> bool {
 }
 
 /// get key ids inner function
-fn get_alg_key_ids_inner<B>(
-  req_or_res: &RequestOrResponse<B>,
+fn get_alg_key_ids_inner<M: HttpMessage>(
+  req_or_res: &M,
 ) -> HyperSigResult<IndexMap<SignatureName, (Option<AlgorithmName>, Option<KeyId>)>> {
   let signature_headers_map = extract_signature_headers_with_name(req_or_res)?;
   let res = signature_headers_map
@@ -662,8 +630,8 @@ fn get_alg_key_ids_inner<B>(
       let alg = headers
         .signature_params()
         .alg
-        .clone()
-        .map(|a| AlgorithmName::from_str(&a))
+        .as_ref()
+        .map(|a| AlgorithmName::from_str(a))
         .transpose()
         .ok()
         .flatten();
@@ -675,8 +643,8 @@ fn get_alg_key_ids_inner<B>(
 }
 
 /// get signature params inner function
-fn get_signature_params_inner<B>(
-  req_or_res: &RequestOrResponse<B>,
+fn get_signature_params_inner<M: HttpMessage>(
+  req_or_res: &M,
 ) -> HyperSigResult<IndexMap<SignatureName, HttpSignatureParams>> {
   let signature_headers_map = extract_signature_headers_with_name(req_or_res)?;
   let res = signature_headers_map
@@ -687,17 +655,17 @@ fn get_signature_params_inner<B>(
 }
 
 /// extract signatures inner function
-fn extract_signatures_inner<B1, B2>(
-  req_or_res: &RequestOrResponse<B1>,
-  req_for_param: Option<&Request<B2>>,
+fn extract_signatures_inner<M: HttpMessage, B>(
+  req_or_res: &M,
+  req_for_param: Option<&Request<B>>,
 ) -> HyperSigResult<IndexMap<SignatureName, (HttpSignatureBase, HttpSignatureHeaders)>> {
   let signature_headers_map = extract_signature_headers_with_name(req_or_res)?;
   let extracted = signature_headers_map
-    .iter()
+    .into_iter()
     .filter_map(|(name, headers)| {
       build_signature_base(req_or_res, headers.signature_params(), req_for_param)
         .ok()
-        .map(|base| (name.clone(), (base, headers.clone())))
+        .map(|base| (name, (base, headers)))
     })
     .collect();
   Ok(extracted)
@@ -707,26 +675,27 @@ fn extract_signatures_inner<B1, B2>(
 async fn verify_message_signatures_inner<T>(
   map_signature_with_base: &IndexMap<String, (HttpSignatureBase, HttpSignatureHeaders)>,
   key_and_id: &[(&T, Option<&str>)],
-) -> HyperSigResult<Vec<HyperSigResult<SignatureName>>>
+) -> Vec<HyperSigResult<SignatureName>>
 where
   T: VerifyingKey + Sync,
 {
   // verify for each key_and_id tuple
-  let res_fut = key_and_id.iter().map(|(key, key_id)| {
-    let filtered = if let Some(key_id) = key_id {
-      map_signature_with_base
-        .iter()
-        .filter(|(_, (base, _))| base.keyid() == Some(key_id))
-        .collect::<IndexMap<_, _>>()
-    } else {
-      map_signature_with_base.iter().collect()
-    };
+  key_and_id
+    .iter()
+    .map(|(key, key_id)| {
+      let filtered = if let Some(key_id) = key_id {
+        map_signature_with_base
+          .iter()
+          .filter(|(_, (base, _))| base.keyid() == Some(key_id))
+          .collect::<IndexMap<_, _>>()
+      } else {
+        map_signature_with_base.iter().collect()
+      };
 
-    // check if any one of the signature headers is valid in async manner
-    async move {
+      // check if any one of the signature headers is valid in async manner
       if filtered.is_empty() {
         return Err(HyperSigError::NoSignatureHeaders(
-          "No signature as appropriate target for verification".to_string(),
+          "No signature as appropriate target for verification",
         ));
       }
       // check if any one of the signature headers is valid
@@ -743,67 +712,157 @@ where
         Ok(successful_sig_names.first().unwrap().clone())
       } else {
         Err(HyperSigError::InvalidSignature(
-          "Invalid signature for the verifying key".to_string(),
+          "Invalid signature for the verifying key",
         ))
       }
-    }
-  });
-  let res = futures::future::join_all(res_fut).await;
-  Ok(res)
+    })
+    .collect()
 }
 
 /* --------------------------------------- */
 
-/// A type to represent either http request or response
-enum RequestOrResponse<'a, B> {
-  Request(&'a Request<B>),
-  Response(&'a Response<B>),
+/// [`HttpMessage`] represents http request or response message we sign or verify.
+trait HttpMessage {
+  fn message_method(&self) -> HyperSigResult<&http::Method>;
+  fn message_uri(&self) -> HyperSigResult<&http::Uri>;
+  fn message_headers(&self) -> &HeaderMap;
+  fn message_status(&self) -> HyperSigResult<http::StatusCode>;
+  /// Validation callback for HTTP Message, containing a component with `req` param.
+  fn on_message_component_req_param(&self, caller_provided_request: bool) -> HyperSigResult<()>;
+  /// Validation callback for HTTP Message, containing a derived component with `req` param.
+  fn on_message_derived_component_req_param(&self) -> HyperSigResult<()>;
+  /// Validation callback for HTTP Message, containing a derived component.
+  fn on_message_derived_component(
+    &self,
+    derived_name: &DerivedComponentName,
+    component_id: &HttpMessageComponentId,
+  ) -> HyperSigResult<()>;
 }
 
-impl<B> RequestOrResponse<'_, B> {
-  fn method(&self) -> HyperSigResult<&http::Method> {
-    match self {
-      RequestOrResponse::Request(req) => Ok(req.method()),
-      _ => Err(HyperSigError::InvalidComponentName(
-        "`method` is only for request".to_string(),
-      )),
+impl<B> HttpMessage for Request<B> {
+  fn message_method(&self) -> HyperSigResult<&http::Method> {
+    Ok(self.method())
+  }
+
+  fn message_uri(&self) -> HyperSigResult<&http::Uri> {
+    Ok(self.uri())
+  }
+
+  fn message_headers(&self) -> &HeaderMap {
+    self.headers()
+  }
+
+  fn message_status(&self) -> HyperSigResult<http::StatusCode> {
+    Err(HyperSigError::InvalidComponentName(
+      "`status` is only for response".into(),
+    ))
+  }
+
+  fn on_message_component_req_param(&self, _caller_provided_request: bool) -> HyperSigResult<()> {
+    Err(HyperSigError::InvalidComponentParam(
+      "`req` is not allowed in request".into(),
+    ))
+  }
+
+  fn on_message_derived_component_req_param(&self) -> HyperSigResult<()> {
+    Ok(())
+  }
+
+  fn on_message_derived_component(
+    &self,
+    derived_name: &DerivedComponentName,
+    _component_id: &HttpMessageComponentId,
+  ) -> HyperSigResult<()> {
+    if matches!(derived_name, DerivedComponentName::Status) {
+      Err(HyperSigError::InvalidComponentName(
+        "`status` is only for response".into(),
+      ))
+    } else {
+      Ok(())
+    }
+  }
+}
+
+impl<B> HttpMessage for Response<B> {
+  fn message_method(&self) -> HyperSigResult<&http::Method> {
+    Err(HyperSigError::InvalidComponentName(
+      "`method` is only for request".into(),
+    ))
+  }
+
+  fn message_uri(&self) -> HyperSigResult<&http::Uri> {
+    Err(HyperSigError::InvalidComponentName(
+      "`uri` is only for request".into(),
+    ))
+  }
+
+  fn message_headers(&self) -> &HeaderMap {
+    self.headers()
+  }
+
+  fn message_status(&self) -> HyperSigResult<http::StatusCode> {
+    Ok(self.status())
+  }
+
+  fn on_message_component_req_param(&self, caller_provided_request: bool) -> HyperSigResult<()> {
+    if caller_provided_request {
+      Ok(())
+    } else {
+      Err(HyperSigError::InvalidComponentParam(
+        "`req` is required for the param but no request is provided".into(),
+      ))
     }
   }
 
-  fn uri(&self) -> HyperSigResult<&http::Uri> {
-    match self {
-      RequestOrResponse::Request(req) => Ok(req.uri()),
-      _ => Err(HyperSigError::InvalidComponentName(
-        "`uri` is only for request".to_string(),
-      )),
-    }
+  fn on_message_derived_component_req_param(&self) -> HyperSigResult<()> {
+    Err(HyperSigError::InvalidComponentParam(
+      "`req`-tagged component must be extracted from the source request".into(),
+    ))
   }
 
-  fn headers(&self) -> &HeaderMap {
-    match self {
-      RequestOrResponse::Request(req) => req.headers(),
-      RequestOrResponse::Response(res) => res.headers(),
-    }
-  }
-
-  fn status(&self) -> HyperSigResult<http::StatusCode> {
-    match self {
-      RequestOrResponse::Response(res) => Ok(res.status()),
-      _ => Err(HyperSigError::InvalidComponentName(
-        "`status` is only for response".to_string(),
-      )),
+  fn on_message_derived_component(
+    &self,
+    derived_name: &DerivedComponentName,
+    component_id: &HttpMessageComponentId,
+  ) -> HyperSigResult<()> {
+    let has_req = component_id
+      .params
+      .0
+      .contains(&HttpMessageComponentParam::Req);
+    if has_req {
+      // `@status` must not have `req` parameter
+      if matches!(derived_name, DerivedComponentName::Status) {
+        Err(HyperSigError::InvalidComponentParam(
+          "`@status` does not accept `req` parameter".to_string(),
+        ))
+      } else {
+        Ok(())
+      }
+    } else {
+      // Response messages can use `@status` and `@signature-params` directly,
+      // or any request-derived component with the `req` parameter (RFC 9421 §2.4).
+      if !matches!(
+        derived_name,
+        DerivedComponentName::Status | DerivedComponentName::SignatureParams
+      ) {
+        Err(HyperSigError::InvalidComponentName(
+          "derived components other than `@status` and `@signature-params` require `req` parameter for response".into(),
+        ))
+      } else {
+        Ok(())
+      }
     }
   }
 }
 
 /// Extract signature and signature-input with signature-name indication from http request and response
-fn extract_signature_headers_with_name<B>(
-  req_or_res: &RequestOrResponse<B>,
+fn extract_signature_headers_with_name<M: HttpMessage>(
+  req_or_res: &M,
 ) -> HyperSigResult<HttpSignatureHeadersMap> {
-  let headers = req_or_res.headers();
+  let headers = req_or_res.message_headers();
   if !(headers.contains_key("signature-input") && headers.contains_key("signature")) {
     return Err(HyperSigError::NoSignatureHeaders(
-      "The request does not have signature and signature-input headers".to_string(),
+      "The request does not have signature and signature-input headers",
     ));
   };
 
@@ -829,11 +888,12 @@ fn extract_signature_headers_with_name<B>(
 /// - req_or_res: the hyper http request or response
 /// - signature_params: the http signature params
 /// - req_for_param: corresponding request to be considered in the signature base in response
-fn build_signature_base<B1, B2>(
-  req_or_res: &RequestOrResponse<B1>,
+fn build_signature_base<M: HttpMessage, B>(
+  req_or_res: &M,
   signature_params: &HttpSignatureParams,
-  req_for_param: Option<&Request<B2>>,
+  req_for_param: Option<&Request<B>>,
 ) -> HyperSigResult<HttpSignatureBase> {
+  let caller_provided_request = req_for_param.is_some();
   let component_lines = signature_params
     .covered_components
     .iter()
@@ -843,41 +903,29 @@ fn build_signature_base<B1, B2>(
         .0
         .contains(&HttpMessageComponentParam::Req)
       {
-        if matches!(req_or_res, RequestOrResponse::Request(_)) {
-          return Err(HyperSigError::InvalidComponentParam(
-            "`req` is not allowed in request".to_string(),
-          ));
-        }
-        if req_for_param.is_none() {
-          return Err(HyperSigError::InvalidComponentParam(
-            "`req` is required for the param".to_string(),
-          ));
-        }
-        let req = RequestOrResponse::Request(req_for_param.unwrap());
-        extract_http_message_component(&req, component_id)
+        req_or_res.on_message_component_req_param(caller_provided_request)?;
+        let req = req_for_param.expect("None case handled above");
+        extract_http_message_component(req, component_id)
       } else {
         extract_http_message_component(req_or_res, component_id)
       }
     })
     .collect::<Result<Vec<_>, _>>()?;
 
-  HttpSignatureBase::try_new(&component_lines, signature_params).map_err(|e| e.into())
+  HttpSignatureBase::try_new(component_lines, signature_params).map_err(|e| e.into())
 }
 
 /// Extract http field from hyper http request/response
-fn extract_http_field<B>(
-  req_or_res: &RequestOrResponse<B>,
+fn extract_http_field<M: HttpMessage>(
+  req_or_res: &M,
   id: &HttpMessageComponentId,
 ) -> HyperSigResult<HttpMessageComponent> {
   let HttpMessageComponentName::HttpField(header_name) = &id.name else {
     return Err(HyperSigError::InvalidComponentName(
-      "invalid http message component name as http field".to_string(),
+      "invalid http message component name as http field".into(),
     ));
   };
-  let headers = match req_or_res {
-    RequestOrResponse::Request(req) => req.headers(),
-    RequestOrResponse::Response(res) => res.headers(),
-  };
+  let headers = req_or_res.message_headers();
 
   let field_values = headers
     .get_all(header_name)
@@ -885,17 +933,17 @@ fn extract_http_field<B>(
     .map(|v| v.to_str().map(|s| s.to_owned()))
     .collect::<Result<Vec<_>, _>>()?;
 
-  HttpMessageComponent::try_from((id, field_values.as_slice())).map_err(|e| e.into())
+  HttpMessageComponent::try_from((id, field_values)).map_err(|e| e.into())
 }
 
 /// Extract derived component from hyper http request/response
-fn extract_derived_component<B>(
-  req_or_res: &RequestOrResponse<B>,
+fn extract_derived_component<M: HttpMessage>(
+  req_or_res: &M,
   id: &HttpMessageComponentId,
 ) -> HyperSigResult<HttpMessageComponent> {
-  let HttpMessageComponentName::Derived(derived_id) = &id.name else {
+  let HttpMessageComponentName::Derived(derived_name) = &id.name else {
     return Err(HyperSigError::InvalidComponentName(
-      "invalid http message component name as derived component".to_string(),
+      "invalid http message component name as derived component".into(),
     ));
   };
   // Validate parameters allowed on derived components (RFC 9421).
@@ -904,7 +952,7 @@ fn extract_derived_component<B>(
   // - `sf`, `key`, `bs`, `tr`: only valid on HTTP field components, not derived components
   id.params.0.iter().try_for_each(|param| match param {
     HttpMessageComponentParam::Name(_)
-      if matches!(derived_id, DerivedComponentName::QueryParam) =>
+      if matches!(derived_name, DerivedComponentName::QueryParam) =>
     {
       Ok(())
     }
@@ -915,69 +963,43 @@ fn extract_derived_component<B>(
     // `build_signature_base` already validates this and re-dispatches extraction against the
     // original request, so `req_or_res` here should always be `Request`.
     // Guard against misuse by callers that bypass `build_signature_base`.
-    HttpMessageComponentParam::Req if matches!(req_or_res, RequestOrResponse::Request(_)) => Ok(()),
-    HttpMessageComponentParam::Req => Err(HyperSigError::InvalidComponentParam(
-      "`req`-tagged component must be extracted from the source request".to_string(),
-    )),
+    HttpMessageComponentParam::Req => req_or_res.on_message_derived_component_req_param(),
     _ => Err(HyperSigError::InvalidComponentParam(format!(
       "parameter `{}` is not allowed on derived components",
       String::from(param.clone())
     ))),
   })?;
 
-  match req_or_res {
-    RequestOrResponse::Request(_) => {
-      if matches!(derived_id, DerivedComponentName::Status) {
-        return Err(HyperSigError::InvalidComponentName(
-          "`status` is only for response".to_string(),
-        ));
-      }
-    }
-    RequestOrResponse::Response(_) => {
-      let has_req = id.params.0.contains(&HttpMessageComponentParam::Req);
-      // Response messages can use `@status` and `@signature-params` directly,
-      // or any request-derived component with the `req` parameter (RFC 9421 §2.4).
-      if !matches!(derived_id, DerivedComponentName::Status)
-        && !matches!(derived_id, DerivedComponentName::SignatureParams)
-        && !has_req
-      {
-        return Err(HyperSigError::InvalidComponentName(
-          "derived components other than `@status` and `@signature-params` require `req` parameter for response".to_string(),
-        ));
-      }
-      // `@status` must not have `req` parameter
-      if matches!(derived_id, DerivedComponentName::Status) && has_req {
-        return Err(HyperSigError::InvalidComponentParam(
-          "`@status` does not accept `req` parameter".to_string(),
-        ));
-      }
-    }
-  }
+  req_or_res.on_message_derived_component(derived_name, id)?;
 
-  let field_values: Vec<String> = match derived_id {
-    DerivedComponentName::Method => vec![req_or_res.method()?.as_str().to_string()],
-    DerivedComponentName::TargetUri => vec![req_or_res.uri()?.to_string()],
+  let field_values: Vec<String> = match derived_name {
+    DerivedComponentName::Method => vec![req_or_res.message_method()?.as_str().to_string()],
+    DerivedComponentName::TargetUri => vec![req_or_res.message_uri()?.to_string()],
     DerivedComponentName::Authority => vec![req_or_res
-      .uri()?
+      .message_uri()?
       .authority()
       .map(|s| s.to_string())
       .unwrap_or("".to_string())],
-    DerivedComponentName::Scheme => vec![req_or_res.uri()?.scheme_str().unwrap_or("").to_string()],
-    DerivedComponentName::RequestTarget => match *req_or_res.method()? {
+    DerivedComponentName::Scheme => vec![req_or_res
+      .message_uri()?
+      .scheme_str()
+      .unwrap_or("")
+      .to_string()],
+    DerivedComponentName::RequestTarget => match *req_or_res.message_method()? {
       http::Method::CONNECT => vec![req_or_res
-        .uri()?
+        .message_uri()?
         .authority()
         .map(|s| s.to_string())
         .unwrap_or("".to_string())],
       http::Method::OPTIONS => vec!["*".to_string()],
       _ => vec![req_or_res
-        .uri()?
+        .message_uri()?
         .path_and_query()
         .map(|s| s.to_string())
         .unwrap_or("".to_string())],
     },
     DerivedComponentName::Path => vec![{
-      let p = req_or_res.uri()?.path();
+      let p = req_or_res.message_uri()?.path();
       if p.is_empty() {
         "/".to_string()
       } else {
@@ -985,34 +1007,34 @@ fn extract_derived_component<B>(
       }
     }],
     DerivedComponentName::Query => vec![req_or_res
-      .uri()?
+      .message_uri()?
       .query()
       .map(|v| format!("?{v}"))
       .unwrap_or("?".to_string())],
     DerivedComponentName::QueryParam => {
-      let query = req_or_res.uri()?.query().unwrap_or("");
+      let query = req_or_res.message_uri()?.query().unwrap_or("");
       query
         .split('&')
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
         .collect::<Vec<_>>()
     }
-    DerivedComponentName::Status => vec![req_or_res.status()?.as_str().to_string()],
+    DerivedComponentName::Status => vec![req_or_res.message_status()?.as_str().to_string()],
     DerivedComponentName::SignatureParams => req_or_res
-      .headers()
+      .message_headers()
       .get_all("signature-input")
       .iter()
       .map(|v| v.to_str().unwrap_or("").to_string())
       .collect::<Vec<_>>(),
   };
 
-  HttpMessageComponent::try_from((id, field_values.as_slice())).map_err(|e| e.into())
+  HttpMessageComponent::try_from((id, field_values)).map_err(|e| e.into())
 }
 
 /* --------------------------------------- */
 /// Extract http message component from hyper http request
-fn extract_http_message_component<B>(
-  req_or_res: &RequestOrResponse<B>,
+fn extract_http_message_component<M: HttpMessage>(
+  req_or_res: &M,
   target_component_id: &HttpMessageComponentId,
 ) -> HyperSigResult<HttpMessageComponent> {
   match &target_component_id.name {

--- a/httpsig-hyper/src/hyper_http_tests.rs
+++ b/httpsig-hyper/src/hyper_http_tests.rs
@@ -21,7 +21,13 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
 "##;
 // const EDDSA_KEY_ID: &str = "gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=";
 const COVERED_COMPONENTS_REQ: &[&str] = &["@method", "date", "content-type", "content-digest"];
-const COVERED_COMPONENTS_RES: &[&str] = &["@status", "\"@method\";req", "date", "content-type", "\"content-digest\";req"];
+const COVERED_COMPONENTS_RES: &[&str] = &[
+  "@status",
+  "\"@method\";req",
+  "date",
+  "content-type",
+  "\"content-digest\";req",
+];
 
 async fn build_request() -> Request<BoxBody> {
   let body = Full::new(&b"{\"hello\": \"world\"}"[..]);
@@ -33,7 +39,10 @@ async fn build_request() -> Request<BoxBody> {
     .header("content-type", "application/json-patch+json")
     .body(body)
     .unwrap();
-  req.set_content_digest(&ContentDigestType::Sha256).await.unwrap()
+  req
+    .set_content_digest(&ContentDigestType::Sha256)
+    .await
+    .unwrap()
 }
 
 async fn build_response() -> Response<BoxBody> {
@@ -45,7 +54,10 @@ async fn build_response() -> Response<BoxBody> {
     .header("content-type", "application/json-patch+json")
     .body(body)
     .unwrap();
-  res.set_content_digest(&ContentDigestType::Sha256).await.unwrap()
+  res
+    .set_content_digest(&ContentDigestType::Sha256)
+    .await
+    .unwrap()
 }
 
 fn build_covered_components_req() -> Vec<HttpMessageComponentId> {
@@ -64,7 +76,9 @@ fn build_covered_components_res() -> Vec<HttpMessageComponentId> {
 
 /// Helper to build a request with query parameters (no content-digest needed)
 fn build_query_request() -> Request<BoxBody> {
-  let body = Full::new(bytes::Bytes::new()).map_err(|never| match never {}).boxed();
+  let body = Full::new(bytes::Bytes::new())
+    .map_err(|never| match never {})
+    .boxed();
   Request::builder()
     .method("GET")
     .uri("https://example.com/path?foo=bar&id=123&x=y")
@@ -78,25 +92,27 @@ fn build_query_request() -> Request<BoxBody> {
 #[tokio::test]
 async fn test_extract_component_from_request() {
   let req = build_request().await;
-  let req_or_res = RequestOrResponse::Request(&req);
 
   let component_id_method = HttpMessageComponentId::try_from("\"@method\"").unwrap();
-  let component = extract_http_message_component(&req_or_res, &component_id_method).unwrap();
+  let component = extract_http_message_component(&req, &component_id_method).unwrap();
   assert_eq!(component.to_string(), "\"@method\": GET");
 
   let component_id = HttpMessageComponentId::try_from("\"date\"").unwrap();
-  let component = extract_http_message_component(&req_or_res, &component_id).unwrap();
-  assert_eq!(component.to_string(), "\"date\": Sun, 09 May 2021 18:30:00 GMT");
+  let component = extract_http_message_component(&req, &component_id).unwrap();
+  assert_eq!(
+    component.to_string(),
+    "\"date\": Sun, 09 May 2021 18:30:00 GMT"
+  );
 
   let component_id = HttpMessageComponentId::try_from("content-type").unwrap();
-  let component = extract_http_field(&req_or_res, &component_id).unwrap();
+  let component = extract_http_field(&req, &component_id).unwrap();
   assert_eq!(
     component.to_string(),
     "\"content-type\": application/json, application/json-patch+json"
   );
 
   let component_id = HttpMessageComponentId::try_from("content-digest").unwrap();
-  let component = extract_http_message_component(&req_or_res, &component_id).unwrap();
+  let component = extract_http_message_component(&req, &component_id).unwrap();
   assert_eq!(
     component.to_string(),
     "\"content-digest\": sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:"
@@ -112,12 +128,20 @@ async fn test_extract_signature_params_from_request() {
     http::HeaderValue::from_static(r##"sig1=("@method" "@authority")"##),
   );
   let component_id = HttpMessageComponentId::try_from("@signature-params").unwrap();
-  let req_or_res = RequestOrResponse::Request(&req);
-  let component = extract_http_message_component(&req_or_res, &component_id).unwrap();
-  assert_eq!(component.to_string(), "\"@signature-params\": (\"@method\" \"@authority\")");
+  let component = extract_http_message_component(&req, &component_id).unwrap();
+  assert_eq!(
+    component.to_string(),
+    "\"@signature-params\": (\"@method\" \"@authority\")"
+  );
   assert_eq!(component.value.to_string(), r##"("@method" "@authority")"##);
-  assert_eq!(component.value.as_field_value(), r##"sig1=("@method" "@authority")"##);
-  assert_eq!(component.value.as_component_value(), r##"("@method" "@authority")"##);
+  assert_eq!(
+    component.value.to_field_value(),
+    r##"sig1=("@method" "@authority")"##
+  );
+  assert_eq!(
+    component.value.as_component_value(),
+    r##"("@method" "@authority")"##
+  );
   assert_eq!(component.value.key(), Some("sig1"));
 }
 
@@ -125,12 +149,17 @@ async fn test_extract_signature_params_from_request() {
 async fn test_build_signature_base_from_request() {
   let req = build_request().await;
 
-  const SIGPARA: &str = r##";created=1704972031;alg="ed25519";keyid="gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=""##;
-  let values = (r##""@method" "content-type" "date" "content-digest""##, SIGPARA);
-  let signature_params = HttpSignatureParams::try_from(format!("({}){}", values.0, values.1).as_str()).unwrap();
+  const SIGPARA: &str =
+    r##";created=1704972031;alg="ed25519";keyid="gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=""##;
+  let values = (
+    r##""@method" "content-type" "date" "content-digest""##,
+    SIGPARA,
+  );
+  let signature_params =
+    HttpSignatureParams::try_from(format!("({}){}", values.0, values.1).as_str()).unwrap();
 
-  let req_or_res = RequestOrResponse::Request(&req);
-  let signature_base = build_signature_base(&req_or_res, &signature_params, None as Option<&Request<()>>).unwrap();
+  let signature_base =
+    build_signature_base(&req, &signature_params, None as Option<&Request<()>>).unwrap();
   assert_eq!(
     signature_base.to_string(),
     r##""@method": GET
@@ -156,8 +185,7 @@ async fn test_extract_tuples_from_request() {
     ),
   );
 
-  let req_or_res = RequestOrResponse::Request(&req);
-  let tuples = extract_signature_headers_with_name(&req_or_res).unwrap();
+  let tuples = extract_signature_headers_with_name(&req).unwrap();
   assert_eq!(tuples.len(), 1);
   assert_eq!(tuples.get("sig11").unwrap().signature_name(), "sig11");
   assert_eq!(
@@ -175,9 +203,19 @@ async fn test_set_verify_message_signature_req() {
   let mut signature_params = HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
   signature_params.set_key_info(&secret_key);
 
-  req.set_message_signature(&signature_params, &secret_key, None).await.unwrap();
-  let signature_input = req.headers().get("signature-input").unwrap().to_str().unwrap();
-  assert!(signature_input.starts_with(r##"sig=("@method" "date" "content-type" "content-digest")"##));
+  req
+    .set_message_signature(&signature_params, &secret_key, None)
+    .await
+    .unwrap();
+  let signature_input = req
+    .headers()
+    .get("signature-input")
+    .unwrap()
+    .to_str()
+    .unwrap();
+  assert!(
+    signature_input.starts_with(r##"sig=("@method" "date" "content-type" "content-digest")"##)
+  );
 
   let public_key = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
   let verification_res = req.verify_message_signature(&public_key, None).await;
@@ -198,11 +236,19 @@ async fn test_set_verify_message_signature_res() {
     .set_message_signature(&signature_params, &secret_key, None, Some(&req))
     .await
     .unwrap();
-  let signature_input = res.headers().get("signature-input").unwrap().to_str().unwrap();
-  assert!(signature_input.starts_with(r##"sig=("@status" "@method";req "date" "content-type" "content-digest";req)"##));
+  let signature_input = res
+    .headers()
+    .get("signature-input")
+    .unwrap()
+    .to_str()
+    .unwrap();
+  assert!(signature_input
+    .starts_with(r##"sig=("@status" "@method";req "date" "content-type" "content-digest";req)"##));
 
   let public_key = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
-  let verification_res = res.verify_message_signature(&public_key, None, Some(&req)).await;
+  let verification_res = res
+    .verify_message_signature(&public_key, None, Some(&req))
+    .await;
   assert!(verification_res.is_ok());
 }
 
@@ -216,7 +262,10 @@ async fn test_expired_signature() {
   signature_params.set_expires(created - 1);
   assert!(signature_params.is_expired());
 
-  req.set_message_signature(&signature_params, &secret_key, None).await.unwrap();
+  req
+    .set_message_signature(&signature_params, &secret_key, None)
+    .await
+    .unwrap();
 
   let public_key = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
   let verification_res = req.verify_message_signature(&public_key, None).await;
@@ -235,8 +284,7 @@ async fn test_set_verify_with_signature_name() {
     .await
     .unwrap();
 
-  let req_or_res = RequestOrResponse::Request(&req);
-  let signature_headers_map = extract_signature_headers_with_name(&req_or_res).unwrap();
+  let signature_headers_map = extract_signature_headers_with_name(&req).unwrap();
   assert_eq!(signature_headers_map.len(), 1);
   assert_eq!(signature_headers_map[0].signature_name(), "custom_sig_name");
 
@@ -252,14 +300,21 @@ async fn test_set_verify_with_key_id() {
   let mut signature_params = HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
   signature_params.set_key_info(&secret_key);
 
-  req.set_message_signature(&signature_params, &secret_key, None).await.unwrap();
+  req
+    .set_message_signature(&signature_params, &secret_key, None)
+    .await
+    .unwrap();
 
   let public_key = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
   let key_id = public_key.key_id();
-  let verification_res = req.verify_message_signature(&public_key, Some(&key_id)).await;
+  let verification_res = req
+    .verify_message_signature(&public_key, Some(&key_id))
+    .await;
   assert!(verification_res.is_ok());
 
-  let verification_res = req.verify_message_signature(&public_key, Some("NotFoundKeyId")).await;
+  let verification_res = req
+    .verify_message_signature(&public_key, Some("NotFoundKeyId"))
+    .await;
   assert!(verification_res.is_err());
 }
 
@@ -269,13 +324,17 @@ const HMACSHA256_SECRET_KEY: &str =
 #[tokio::test]
 async fn test_set_verify_with_key_id_hmac_sha256() {
   let mut req = build_request().await;
-  let secret_key = SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
+  let secret_key =
+    SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
   let mut signature_params = HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
   signature_params.set_key_info(&secret_key);
   // Random nonce is highly recommended for HMAC
   signature_params.set_random_nonce();
 
-  req.set_message_signature(&signature_params, &secret_key, None).await.unwrap();
+  req
+    .set_message_signature(&signature_params, &secret_key, None)
+    .await
+    .unwrap();
 
   let org_key_id = VerifyingKey::key_id(&secret_key);
   let (alg, key_id) = req.get_alg_key_ids().unwrap().into_iter().next().unwrap().1;
@@ -283,10 +342,14 @@ async fn test_set_verify_with_key_id_hmac_sha256() {
   let key_id = key_id.unwrap();
   assert_eq!(org_key_id, key_id);
   let verification_key = SharedKey::from_base64(&alg, HMACSHA256_SECRET_KEY).unwrap();
-  let verification_res = req.verify_message_signature(&verification_key, Some(&key_id)).await;
+  let verification_res = req
+    .verify_message_signature(&verification_key, Some(&key_id))
+    .await;
   assert!(verification_res.is_ok());
 
-  let verification_res = req.verify_message_signature(&verification_key, Some("NotFoundKeyId")).await;
+  let verification_res = req
+    .verify_message_signature(&verification_key, Some("NotFoundKeyId"))
+    .await;
   assert!(verification_res.is_err());
 }
 
@@ -297,11 +360,17 @@ async fn test_get_alg_key_ids() {
   let mut signature_params = HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
   signature_params.set_key_info(&secret_key);
 
-  req.set_message_signature(&signature_params, &secret_key, None).await.unwrap();
+  req
+    .set_message_signature(&signature_params, &secret_key, None)
+    .await
+    .unwrap();
   let key_ids = req.get_alg_key_ids().unwrap();
   assert_eq!(key_ids.len(), 1);
   assert_eq!(key_ids[0].0.as_ref().unwrap(), &AlgorithmName::Ed25519);
-  assert_eq!(key_ids[0].1.as_ref().unwrap(), "gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=");
+  assert_eq!(
+    key_ids[0].1.as_ref().unwrap(),
+    "gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is="
+  );
 }
 
 const P256_SECRET_KEY: &str = r##"-----BEGIN PRIVATE KEY-----
@@ -320,22 +389,30 @@ async fn test_set_verify_multiple_signatures() {
   let mut req = build_request().await;
 
   let secret_key_eddsa = SecretKey::from_pem(&AlgorithmName::Ed25519, EDDSA_SECRET_KEY).unwrap();
-  let mut signature_params_eddsa = HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
+  let mut signature_params_eddsa =
+    HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
   signature_params_eddsa.set_key_info(&secret_key_eddsa);
 
-  let secret_key_p256 = SecretKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_SECRET_KEY).unwrap();
-  let mut signature_params_hmac = HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
+  let secret_key_p256 =
+    SecretKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_SECRET_KEY).unwrap();
+  let mut signature_params_hmac =
+    HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
   signature_params_hmac.set_key_info(&secret_key_p256);
 
   let params_key_name = &[
-    (&signature_params_eddsa, &secret_key_eddsa, Some("eddsa_sig")),
+    (
+      &signature_params_eddsa,
+      &secret_key_eddsa,
+      Some("eddsa_sig"),
+    ),
     (&signature_params_hmac, &secret_key_p256, Some("p256_sig")),
   ];
 
   req.set_message_signatures(params_key_name).await.unwrap();
 
   let public_key_eddsa = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
-  let public_key_p256 = PublicKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_PUBLIC_KEY).unwrap();
+  let public_key_p256 =
+    PublicKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_PUBLIC_KEY).unwrap();
   let key_id_eddsa = public_key_eddsa.key_id();
   let key_id_p256 = public_key_p256.key_id();
 
@@ -362,7 +439,9 @@ fn test_blocking_set_verify_message_signature_req() {
   let mut signature_params = HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
   signature_params.set_key_info(&secret_key);
 
-  req.set_message_signature_sync(&signature_params, &secret_key, None).unwrap();
+  req
+    .set_message_signature_sync(&signature_params, &secret_key, None)
+    .unwrap();
 
   let public_key = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
   let verification_res = req.verify_message_signature_sync(&public_key, None);
@@ -413,7 +492,10 @@ fn test_query_param_sign_verify_sync() {
     req.headers().get("signature-input").is_some(),
     "signature-input header is missing"
   );
-  assert!(req.headers().get("signature").is_some(), "signature header is missing");
+  assert!(
+    req.headers().get("signature").is_some(),
+    "signature header is missing"
+  );
 
   let public_key = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
   let verification_res = req.verify_message_signature_sync(&public_key, None);
@@ -449,7 +531,10 @@ async fn test_query_param_sign_verify_async() {
     req.headers().get("signature-input").is_some(),
     "signature-input header is missing"
   );
-  assert!(req.headers().get("signature").is_some(), "signature header is missing");
+  assert!(
+    req.headers().get("signature").is_some(),
+    "signature header is missing"
+  );
 
   let public_key = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
   let verification_res = req.verify_message_signature(&public_key, None).await;
@@ -465,12 +550,11 @@ async fn test_query_param_sign_verify_async() {
 #[test]
 fn test_extract_derived_component_rejects_name_on_non_query_param() {
   let req = build_query_request();
-  let req_or_res = RequestOrResponse::Request(&req);
   // `@method;name="foo"` is invalid — `name` is only for `@query-param`
   let id = HttpMessageComponentId::try_from("\"@method\";name=\"foo\"");
   // component_id parsing itself may reject this; if it doesn't, extraction should
   if let Ok(id) = id {
-    let result = extract_derived_component(&req_or_res, &id);
+    let result = extract_derived_component(&req, &id);
     assert!(result.is_err(), "expected error for `name` on `@method`");
   }
 }
@@ -478,12 +562,14 @@ fn test_extract_derived_component_rejects_name_on_non_query_param() {
 #[test]
 fn test_extract_derived_component_rejects_sf_on_derived() {
   let req = build_query_request();
-  let req_or_res = RequestOrResponse::Request(&req);
   // `@method;sf` is invalid — `sf` is only for HTTP field components
   let id = HttpMessageComponentId::try_from("\"@method\";sf");
   if let Ok(id) = id {
-    let result = extract_derived_component(&req_or_res, &id);
-    assert!(result.is_err(), "expected error for `sf` on derived component");
+    let result = extract_derived_component(&req, &id);
+    assert!(
+      result.is_err(),
+      "expected error for `sf` on derived component"
+    );
   }
 }
 
@@ -492,7 +578,9 @@ fn test_extract_derived_component_rejects_sf_on_derived() {
 #[tokio::test]
 async fn test_set_message_signature_propagates_build_error() {
   // Use `@status` on a request — this is invalid and must return Err, not Ok
-  let body = Full::new(bytes::Bytes::new()).map_err(|never| match never {}).boxed();
+  let body = Full::new(bytes::Bytes::new())
+    .map_err(|never| match never {})
+    .boxed();
   let mut req: Request<BoxBody> = Request::builder()
     .method("GET")
     .uri("https://example.com/")
@@ -507,14 +595,19 @@ async fn test_set_message_signature_propagates_build_error() {
   let result = req
     .set_message_signature(&signature_params, &secret_key, None as Option<&str>)
     .await;
-  assert!(result.is_err(), "expected Err when using `@status` on request, got Ok");
+  assert!(
+    result.is_err(),
+    "expected Err when using `@status` on request, got Ok"
+  );
 }
 
 #[cfg(feature = "blocking")]
 #[test]
 fn test_set_message_signature_sync_propagates_build_error() {
   // Same as above but for sync path
-  let body = Full::new(bytes::Bytes::new()).map_err(|never| match never {}).boxed();
+  let body = Full::new(bytes::Bytes::new())
+    .map_err(|never| match never {})
+    .boxed();
   let mut req: Request<BoxBody> = Request::builder()
     .method("GET")
     .uri("https://example.com/")
@@ -527,7 +620,10 @@ fn test_set_message_signature_sync_propagates_build_error() {
   signature_params.set_key_info(&secret_key);
 
   let result = req.set_message_signature_sync(&signature_params, &secret_key, None);
-  assert!(result.is_err(), "expected Err when using `@status` on request, got Ok");
+  assert!(
+    result.is_err(),
+    "expected Err when using `@status` on request, got Ok"
+  );
 }
 
 // ---- RFC 9421 §2.2: Derived component extraction values ----
@@ -536,41 +632,43 @@ fn test_set_message_signature_sync_propagates_build_error() {
 fn test_extract_derived_components_values() {
   let req = build_query_request();
   // URI: https://example.com/path?foo=bar&id=123&x=y
-  let req_or_res = RequestOrResponse::Request(&req);
 
   // @method (§2.2.1)
   let id = HttpMessageComponentId::try_from("@method").unwrap();
-  let c = extract_derived_component(&req_or_res, &id).unwrap();
+  let c = extract_derived_component(&req, &id).unwrap();
   assert_eq!(c.to_string(), "\"@method\": GET");
 
   // @target-uri (§2.2.2)
   let id = HttpMessageComponentId::try_from("@target-uri").unwrap();
-  let c = extract_derived_component(&req_or_res, &id).unwrap();
-  assert_eq!(c.to_string(), "\"@target-uri\": https://example.com/path?foo=bar&id=123&x=y");
+  let c = extract_derived_component(&req, &id).unwrap();
+  assert_eq!(
+    c.to_string(),
+    "\"@target-uri\": https://example.com/path?foo=bar&id=123&x=y"
+  );
 
   // @authority (§2.2.3)
   let id = HttpMessageComponentId::try_from("@authority").unwrap();
-  let c = extract_derived_component(&req_or_res, &id).unwrap();
+  let c = extract_derived_component(&req, &id).unwrap();
   assert_eq!(c.to_string(), "\"@authority\": example.com");
 
   // @scheme (§2.2.4)
   let id = HttpMessageComponentId::try_from("@scheme").unwrap();
-  let c = extract_derived_component(&req_or_res, &id).unwrap();
+  let c = extract_derived_component(&req, &id).unwrap();
   assert_eq!(c.to_string(), "\"@scheme\": https");
 
   // @path (§2.2.6)
   let id = HttpMessageComponentId::try_from("@path").unwrap();
-  let c = extract_derived_component(&req_or_res, &id).unwrap();
+  let c = extract_derived_component(&req, &id).unwrap();
   assert_eq!(c.to_string(), "\"@path\": /path");
 
   // @query (§2.2.7)
   let id = HttpMessageComponentId::try_from("@query").unwrap();
-  let c = extract_derived_component(&req_or_res, &id).unwrap();
+  let c = extract_derived_component(&req, &id).unwrap();
   assert_eq!(c.to_string(), "\"@query\": ?foo=bar&id=123&x=y");
 
   // @query-param;name="id" (§2.2.8)
   let id = HttpMessageComponentId::try_from("\"@query-param\";name=\"id\"").unwrap();
-  let c = extract_derived_component(&req_or_res, &id).unwrap();
+  let c = extract_derived_component(&req, &id).unwrap();
   assert_eq!(c.to_string(), "\"@query-param\";name=\"id\": 123");
 }
 
@@ -581,7 +679,9 @@ async fn test_response_with_query_param_req_sign_verify() {
   // Build a request with query params
   let req = build_query_request();
   // Build a response
-  let body = Full::new(bytes::Bytes::new()).map_err(|never| match never {}).boxed();
+  let body = Full::new(bytes::Bytes::new())
+    .map_err(|never| match never {})
+    .boxed();
   let mut res: Response<BoxBody> = Response::builder().status(200).body(body).unwrap();
 
   // Response signature covering @status + @query-param;name="id";req
@@ -601,20 +701,37 @@ async fn test_response_with_query_param_req_sign_verify() {
     .await
     .unwrap();
 
-  assert!(req.headers().get("signature-input").is_none(), "request should not be modified");
-  assert!(res.headers().get("signature-input").is_some(), "signature-input header is missing on response");
-  assert!(res.headers().get("signature").is_some(), "signature header is missing on response");
+  assert!(
+    req.headers().get("signature-input").is_none(),
+    "request should not be modified"
+  );
+  assert!(
+    res.headers().get("signature-input").is_some(),
+    "signature-input header is missing on response"
+  );
+  assert!(
+    res.headers().get("signature").is_some(),
+    "signature header is missing on response"
+  );
 
   let public_key = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
-  let verification_res = res.verify_message_signature(&public_key, None, Some(&req)).await;
-  assert!(verification_res.is_ok(), "signature verification failed: {:?}", verification_res.err());
+  let verification_res = res
+    .verify_message_signature(&public_key, None, Some(&req))
+    .await;
+  assert!(
+    verification_res.is_ok(),
+    "signature verification failed: {:?}",
+    verification_res.err()
+  );
 }
 
 // ---- RFC 9421: Response must reject request-derived components without `req` ----
 
 #[tokio::test]
 async fn test_response_rejects_derived_component_without_req() {
-  let body = Full::new(bytes::Bytes::new()).map_err(|never| match never {}).boxed();
+  let body = Full::new(bytes::Bytes::new())
+    .map_err(|never| match never {})
+    .boxed();
   let mut res: Response<BoxBody> = Response::builder().status(200).body(body).unwrap();
 
   // `@method` without `req` on a response — must fail
@@ -628,7 +745,15 @@ async fn test_response_rejects_derived_component_without_req() {
   signature_params.set_key_info(&secret_key);
 
   let result = res
-    .set_message_signature(&signature_params, &secret_key, None, None as Option<&Request<()>>)
+    .set_message_signature(
+      &signature_params,
+      &secret_key,
+      None,
+      None as Option<&Request<()>>,
+    )
     .await;
-  assert!(result.is_err(), "expected Err when using `@method` without `req` on response");
+  assert!(
+    result.is_err(),
+    "expected Err when using `@method` without `req` on response"
+  );
 }

--- a/httpsig-hyper/src/lib.rs
+++ b/httpsig-hyper/src/lib.rs
@@ -60,9 +60,9 @@ impl std::str::FromStr for ContentDigestType {
 pub use error::{HyperDigestError, HyperDigestResult, HyperSigError, HyperSigResult};
 pub use httpsig::prelude;
 pub use hyper_content_digest::{ContentDigest, RequestContentDigest, ResponseContentDigest};
-pub use hyper_http::{
-  MessageSignature, MessageSignatureReq, MessageSignatureReqSync, MessageSignatureRes, MessageSignatureResSync,
-};
+pub use hyper_http::{MessageSignature, MessageSignatureReq, MessageSignatureRes};
+#[cfg(feature = "blocking")]
+pub use hyper_http::{MessageSignatureReqSync, MessageSignatureResSync};
 
 /* ----------------------------------------------------------------- */
 #[cfg(test)]

--- a/httpsig-hyper/src/lib.rs
+++ b/httpsig-hyper/src/lib.rs
@@ -21,34 +21,45 @@
 //! will panic. If you are already in an async context, use the async methods directly.
 
 mod error;
+#[cfg(any(feature = "digest-sha256", feature = "digest-sha512"))]
 mod hyper_content_digest;
 mod hyper_http;
 
 // hyper's http specific extension to generate and verify http signature
 
 /// content-digest header name
+#[cfg(any(feature = "digest-sha256", feature = "digest-sha512"))]
 const CONTENT_DIGEST_HEADER: &str = "content-digest";
 
 /// content-digest header type
+#[cfg(any(feature = "digest-sha256", feature = "digest-sha512"))]
 pub enum ContentDigestType {
+  #[cfg(feature = "digest-sha256")]
   Sha256,
+  #[cfg(feature = "digest-sha512")]
   Sha512,
 }
 
+#[cfg(any(feature = "digest-sha256", feature = "digest-sha512"))]
 impl std::fmt::Display for ContentDigestType {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
+      #[cfg(feature = "digest-sha256")]
       ContentDigestType::Sha256 => write!(f, "sha-256"),
+      #[cfg(feature = "digest-sha512")]
       ContentDigestType::Sha512 => write!(f, "sha-512"),
     }
   }
 }
 
+#[cfg(any(feature = "digest-sha256", feature = "digest-sha512"))]
 impl std::str::FromStr for ContentDigestType {
   type Err = error::HyperDigestError;
   fn from_str(s: &str) -> Result<Self, Self::Err> {
     match s {
+      #[cfg(feature = "digest-sha256")]
       "sha-256" => Ok(ContentDigestType::Sha256),
+      #[cfg(feature = "digest-sha512")]
       "sha-512" => Ok(ContentDigestType::Sha512),
       _ => Err(error::HyperDigestError::InvalidContentDigestType(
         s.to_string(),
@@ -59,13 +70,14 @@ impl std::str::FromStr for ContentDigestType {
 
 pub use error::{HyperDigestError, HyperDigestResult, HyperSigError, HyperSigResult};
 pub use httpsig::prelude;
+#[cfg(any(feature = "digest-sha256", feature = "digest-sha512"))]
 pub use hyper_content_digest::{ContentDigest, RequestContentDigest, ResponseContentDigest};
 pub use hyper_http::{MessageSignature, MessageSignatureReq, MessageSignatureRes};
 #[cfg(feature = "blocking")]
 pub use hyper_http::{MessageSignatureReqSync, MessageSignatureResSync};
 
 /* ----------------------------------------------------------------- */
-#[cfg(test)]
+#[cfg(all(test, feature = "digest-sha256"))]
 mod tests {
   use super::{prelude::*, *};
   use http::{Request, Response};
@@ -127,6 +139,7 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
   #[test]
   fn test_content_digest_type() {
     assert_eq!(ContentDigestType::Sha256.to_string(), "sha-256");
+    #[cfg(feature = "digest-sha512")]
     assert_eq!(ContentDigestType::Sha512.to_string(), "sha-512");
   }
 

--- a/httpsig-hyper/src/lib.rs
+++ b/httpsig-hyper/src/lib.rs
@@ -50,7 +50,9 @@ impl std::str::FromStr for ContentDigestType {
     match s {
       "sha-256" => Ok(ContentDigestType::Sha256),
       "sha-512" => Ok(ContentDigestType::Sha512),
-      _ => Err(error::HyperDigestError::InvalidContentDigestType(s.to_string())),
+      _ => Err(error::HyperDigestError::InvalidContentDigestType(
+        s.to_string(),
+      )),
     }
   }
 }
@@ -83,7 +85,13 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
   // const EDDSA_KEY_ID: &str = "gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is";
 
   const COVERED_COMPONENTS_REQ: &[&str] = &["@method", "date", "content-type", "content-digest"];
-  const COVERED_COMPONENTS_RES: &[&str] = &["@status", "\"@method\";req", "date", "content-type", "\"content-digest\";req"];
+  const COVERED_COMPONENTS_RES: &[&str] = &[
+    "@status",
+    "\"@method\";req",
+    "date",
+    "content-type",
+    "\"content-digest\";req",
+  ];
 
   async fn build_request() -> Request<BoxBody> {
     let body = Full::new(&b"{\"hello\": \"world\"}"[..]);
@@ -95,7 +103,10 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
         .header("content-type", "application/json-patch+json")
         .body(body)
         .unwrap();
-    req.set_content_digest(&ContentDigestType::Sha256).await.unwrap()
+    req
+      .set_content_digest(&ContentDigestType::Sha256)
+      .await
+      .unwrap()
   }
 
   async fn build_response() -> Response<BoxBody> {
@@ -107,7 +118,10 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
       .header("content-type", "application/json-patch+json")
       .body(body)
       .unwrap();
-    res.set_content_digest(&ContentDigestType::Sha256).await.unwrap()
+    res
+      .set_content_digest(&ContentDigestType::Sha256)
+      .await
+      .unwrap()
   }
 
   #[test]
@@ -139,7 +153,12 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
       .set_message_signature(&signature_params, &secret_key, Some("custom_sig_name"))
       .await
       .unwrap();
-    let signature_input = req.headers().get("signature-input").unwrap().to_str().unwrap();
+    let signature_input = req
+      .headers()
+      .get("signature-input")
+      .unwrap()
+      .to_str()
+      .unwrap();
     let signature = req.headers().get("signature").unwrap().to_str().unwrap();
     assert!(signature_input.starts_with(r##"custom_sig_name=("##));
     assert!(signature.starts_with(r##"custom_sig_name=:"##));
@@ -153,10 +172,14 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
 
     // verify with checking key_id
     let key_id = public_key.key_id();
-    let verification_res = req.verify_message_signature(&public_key, Some(&key_id)).await;
+    let verification_res = req
+      .verify_message_signature(&public_key, Some(&key_id))
+      .await;
     assert!(verification_res.is_ok());
 
-    let verification_res = req.verify_message_signature(&public_key, Some("NotFoundKeyId")).await;
+    let verification_res = req
+      .verify_message_signature(&public_key, Some("NotFoundKeyId"))
+      .await;
     assert!(verification_res.is_err());
   }
 
@@ -181,10 +204,20 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
 
     // set custom signature name, and `req` field param if needed (e.g., request method, uri, content-digest, etc.) included only in response
     res
-      .set_message_signature(&signature_params, &secret_key, Some("custom_sig_name"), Some(&req))
+      .set_message_signature(
+        &signature_params,
+        &secret_key,
+        Some("custom_sig_name"),
+        Some(&req),
+      )
       .await
       .unwrap();
-    let signature_input = res.headers().get("signature-input").unwrap().to_str().unwrap();
+    let signature_input = res
+      .headers()
+      .get("signature-input")
+      .unwrap()
+      .to_str()
+      .unwrap();
     let signature = res.headers().get("signature").unwrap().to_str().unwrap();
     assert!(signature_input.starts_with(r##"custom_sig_name=("##));
     assert!(signature.starts_with(r##"custom_sig_name=:"##));
@@ -193,7 +226,9 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
     // get algorithm from signature params
     let (alg, _key_id) = res.get_alg_key_ids().unwrap().into_iter().next().unwrap().1;
     let public_key = PublicKey::from_pem(&alg.unwrap(), EDDSA_PUBLIC_KEY).unwrap();
-    let verification_res = res.verify_message_signature(&public_key, None, Some(&req)).await;
+    let verification_res = res
+      .verify_message_signature(&public_key, None, Some(&req))
+      .await;
     assert!(verification_res.is_ok());
     let verification_res = res
       .verify_message_signature(&public_key, None, None as Option<&Request<()>>)
@@ -202,7 +237,9 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
 
     // verify with checking key_id
     let key_id = public_key.key_id();
-    let verification_res = res.verify_message_signature(&public_key, Some(&key_id), Some(&req)).await;
+    let verification_res = res
+      .verify_message_signature(&public_key, Some(&key_id), Some(&req))
+      .await;
     assert!(verification_res.is_ok());
 
     let verification_res = res
@@ -227,7 +264,9 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
     // set key information, alg and keyid
     signature_params.set_key_info(&secret_key);
     // set signature
-    req.set_message_signature_sync(&signature_params, &secret_key, None).unwrap();
+    req
+      .set_message_signature_sync(&signature_params, &secret_key, None)
+      .unwrap();
 
     let (alg, _key_id) = req.get_alg_key_ids().unwrap().into_iter().next().unwrap().1;
     let public_key = PublicKey::from_pem(&alg.unwrap(), EDDSA_PUBLIC_KEY).unwrap();

--- a/httpsig/Cargo.toml
+++ b/httpsig/Cargo.toml
@@ -14,30 +14,31 @@ rust-version.workspace = true
 
 [features]
 default = []
-rsa-signature = ["rsa"]
+ed25519-signature = ["dep:ed25519-compact"]
+rsa-signature = ["dep:rsa"]
 
 [dependencies]
 thiserror = { version = "2.0.18" }
 tracing = { version = "0.1.44" }
 rustc-hash = { version = "2.1.1" }
 indexmap = { version = "2.11.4" }
-rand = { version = "0.10.0" }
+rand = { version = "0.10" }
 
 # crypto
 pkcs8 = { version = "0.10.2", default-features = false, features = ["pem"] }
 spki = { version = "0.7.3", default-features = false, features = ["pem"] }
 sec1 = { version = "0.7.3", default-features = false, features = ["der"] }
-ed25519-compact = { version = "2.2.0", default-features = false, features = [
+ed25519-compact = { version = "2.2", default-features = false, features = [
   "random",
-] }
-ecdsa = { version = "0.16.9", default-features = false, features = [
+], optional = true }
+ecdsa = { version = "0.16", default-features = false, features = [
   "arithmetic",
 ] }
-p256 = { version = "0.13.2", default-features = false, features = [
+p256 = { version = "0.13", default-features = false, features = [
   "arithmetic",
   "ecdsa",
 ] }
-p384 = { version = "0.13.1", default-features = false, features = [
+p384 = { version = "0.13", default-features = false, features = [
   "arithmetic",
   "ecdsa",
 ] }

--- a/httpsig/Cargo.toml
+++ b/httpsig/Cargo.toml
@@ -14,8 +14,14 @@ rust-version.workspace = true
 
 [features]
 default = []
+ecdsa-p256-sha256-signature = ["dep:p256", "dep:sha2", "dep:ecdsa"]
+ecdsa-p384-sha384-signature = ["dep:p384", "dep:sha2", "dep:ecdsa"]
 ed25519-signature = ["dep:ed25519-compact"]
+hmac-sha256-signature = ["dep:hmac", "dep:sha2"]
 rsa-signature = ["dep:rsa"]
+key-id = ["dep:p256"]
+der = ["dep:pkcs8"]
+pem = ["der", "pkcs8/pem", "dep:spki", "spki/pem"]
 
 [dependencies]
 thiserror = { version = "2.0.18" }
@@ -25,26 +31,25 @@ indexmap = { version = "2.11.4" }
 rand = { version = "0.10" }
 
 # crypto
-pkcs8 = { version = "0.10.2", default-features = false, features = ["pem"] }
-spki = { version = "0.7.3", default-features = false, features = ["pem"] }
-sec1 = { version = "0.7.3", default-features = false, features = ["der"] }
+pkcs8 = { version = "0.10.2", optional = true }
+spki = { version = "0.7.3", optional = true }
+sec1 = { version = "0.7.3", default-features = false }
 ed25519-compact = { version = "2.2", default-features = false, features = [
   "random",
 ], optional = true }
 ecdsa = { version = "0.16", default-features = false, features = [
   "arithmetic",
-] }
+], optional = true }
 p256 = { version = "0.13", default-features = false, features = [
   "arithmetic",
   "ecdsa",
-] }
+], optional = true }
 p384 = { version = "0.13", default-features = false, features = [
   "arithmetic",
   "ecdsa",
-] }
-hmac = { version = "0.12.1" }
-sha2 = { version = "0.10.9", default-features = false }
-bytes = { version = "1.11.1" }
+], optional = true }
+hmac = { version = "0.12.1", optional = true }
+sha2 = { version = "0.10.9", default-features = false, optional = true }
 
 # rsa is optional
 rsa = { version = "0.10.0-rc.15", default-features = false, optional = true, features = [
@@ -59,4 +64,10 @@ base64 = { version = "0.22.1" }
 sfv = { version = "0.14.0" }
 
 [dev-dependencies]
+httpsig = { path = ".", features = [
+  "ed25519-signature",
+  "hmac-sha256-signature",
+  "pem",
+  "key-id",
+] }
 rand-085 = { package = "rand", version = "0.8.5" } # testing only

--- a/httpsig/src/crypto/asymmetric.rs
+++ b/httpsig/src/crypto/asymmetric.rs
@@ -66,12 +66,14 @@ impl SecretKey {
     match alg {
       AlgorithmName::EcdsaP256Sha256 => {
         debug!("Read P256 private key");
-        let sk = EcSecretKey::from_bytes(bytes.into()).map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
+        let sk = EcSecretKey::from_bytes(bytes.into())
+          .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string().into()))?;
         Ok(Self::EcdsaP256Sha256(sk))
       }
       AlgorithmName::EcdsaP384Sha384 => {
         debug!("Read P384 private key");
-        let sk = EcSecretKey::from_bytes(bytes.into()).map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
+        let sk = EcSecretKey::from_bytes(bytes.into())
+          .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string().into()))?;
         Ok(Self::EcdsaP384Sha384(sk))
       }
       AlgorithmName::Ed25519 => {
@@ -85,23 +87,32 @@ impl SecretKey {
       AlgorithmName::RsaV1_5Sha256 => {
         debug!("Read RSA private key");
         // read PrivateKeyInfo.private_key as RsaPrivateKey (RFC 3447), which is DER encoded RSAPrivateKey in PKCS#1
-        let sk = RsaPrivateKey::from_pkcs1_der(bytes).map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
-        Ok(Self::RsaV1_5Sha256(pkcs1v15::SigningKey::<rsa::sha2::Sha256>::new(sk)))
+        let sk = RsaPrivateKey::from_pkcs1_der(bytes)
+          .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string().into()))?;
+        Ok(Self::RsaV1_5Sha256(
+          pkcs1v15::SigningKey::<rsa::sha2::Sha256>::new(sk),
+        ))
       }
       #[cfg(feature = "rsa-signature")]
       AlgorithmName::RsaPssSha512 => {
         debug!("Read RSA-PSS private key");
         // read PrivateKeyInfo.private_key as RsaPrivateKey (RFC 3447), which is DER encoded RSAPrivateKey in PKCS#1
-        let sk = RsaPrivateKey::from_pkcs1_der(bytes).map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
-        Ok(Self::RsaPssSha512(pss::SigningKey::<rsa::sha2::Sha512>::new(sk)))
+        let sk = RsaPrivateKey::from_pkcs1_der(bytes)
+          .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string().into()))?;
+        Ok(Self::RsaPssSha512(
+          pss::SigningKey::<rsa::sha2::Sha512>::new(sk),
+        ))
       }
-      _ => Err(HttpSigError::ParsePrivateKeyError("Unsupported algorithm".to_string())),
+      _ => Err(HttpSigError::ParsePrivateKeyError(
+        "Unsupported algorithm".into(),
+      )),
     }
   }
   /// parse der
   /// Derive secret key from der bytes
   pub fn from_der(alg: &AlgorithmName, der: &[u8]) -> HttpSigResult<Self> {
-    let pki = PrivateKeyInfo::from_der(der).map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
+    let pki = PrivateKeyInfo::from_der(der)
+      .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string().into()))?;
 
     let sk_bytes = match pki.algorithm.oid.to_string().as_ref() {
       // ec
@@ -109,18 +120,26 @@ impl SecretKey {
         let param = pki
           .algorithm
           .parameters_oid()
-          .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
+          .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string().into()))?;
         let algorithm_name = match param.to_string().as_ref() {
           params_oids::Secp256r1 => AlgorithmName::EcdsaP256Sha256,
           params_oids::Secp384r1 => AlgorithmName::EcdsaP384Sha384,
-          _ => return Err(HttpSigError::ParsePrivateKeyError("Unsupported curve".to_string())),
+          _ => {
+            return Err(HttpSigError::ParsePrivateKeyError(
+              "Unsupported curve".into(),
+            ))
+          }
         };
         // assert algorithm
         if algorithm_name != *alg {
-          return Err(HttpSigError::ParsePrivateKeyError("Algorithm mismatch".to_string()));
+          return Err(HttpSigError::ParsePrivateKeyError(
+            "Algorithm mismatch".into(),
+          ));
         }
         let sk_bytes = sec1::EcPrivateKey::try_from(pki.private_key)
-          .map_err(|e| HttpSigError::ParsePrivateKeyError(format!("Error decoding EcPrivateKey: {e}")))?
+          .map_err(|e| {
+            HttpSigError::ParsePrivateKeyError(format!("Error decoding EcPrivateKey: {e}").into())
+          })?
           .private_key;
         sk_bytes
       }
@@ -128,7 +147,9 @@ impl SecretKey {
       algorithm_oids::Ed25519 => {
         // assert algorithm
         if AlgorithmName::Ed25519 != *alg {
-          return Err(HttpSigError::ParsePrivateKeyError("Algorithm mismatch".to_string()));
+          return Err(HttpSigError::ParsePrivateKeyError(
+            "Algorithm mismatch".into(),
+          ));
         }
         &pki.private_key[2..]
       }
@@ -138,11 +159,19 @@ impl SecretKey {
         // assert algorithm
         match alg {
           AlgorithmName::RsaV1_5Sha256 | AlgorithmName::RsaPssSha512 => {}
-          _ => return Err(HttpSigError::ParsePrivateKeyError("Algorithm mismatch".to_string())),
+          _ => {
+            return Err(HttpSigError::ParsePrivateKeyError(
+              "Algorithm mismatch".into(),
+            ))
+          }
         }
         pki.private_key
       }
-      _ => return Err(HttpSigError::ParsePrivateKeyError("Unsupported algorithm".to_string())),
+      _ => {
+        return Err(HttpSigError::ParsePrivateKeyError(
+          "Unsupported algorithm".into(),
+        ))
+      }
     };
     let sk = Self::from_bytes(alg, sk_bytes)?;
     Ok(sk)
@@ -150,9 +179,10 @@ impl SecretKey {
 
   /// Derive secret key from pem string
   pub fn from_pem(alg: &AlgorithmName, pem: &str) -> HttpSigResult<Self> {
-    let (tag, doc) = Document::from_pem(pem).map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
+    let (tag, doc) = Document::from_pem(pem)
+      .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string().into()))?;
     if tag != "PRIVATE KEY" {
-      return Err(HttpSigError::ParsePrivateKeyError("Invalid tag".to_string()));
+      return Err(HttpSigError::ParsePrivateKeyError("Invalid tag".into()));
     };
     Self::from_der(alg, doc.as_bytes())
   }
@@ -261,47 +291,56 @@ impl PublicKey {
     match alg {
       AlgorithmName::EcdsaP256Sha256 => {
         debug!("Read P256 public key");
-        let pk = EcPublicKey::from_sec1_bytes(bytes).map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
+        let pk = EcPublicKey::from_sec1_bytes(bytes)
+          .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string().into()))?;
         Ok(Self::EcdsaP256Sha256(pk))
       }
       AlgorithmName::EcdsaP384Sha384 => {
         debug!("Read P384 public key");
-        let pk = EcPublicKey::from_sec1_bytes(bytes).map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
+        let pk = EcPublicKey::from_sec1_bytes(bytes)
+          .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string().into()))?;
         Ok(Self::EcdsaP384Sha384(pk))
       }
       AlgorithmName::Ed25519 => {
         debug!("Read Ed25519 public key");
-        let pk = ed25519_compact::PublicKey::from_slice(bytes).map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
+        let pk = ed25519_compact::PublicKey::from_slice(bytes)
+          .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string().into()))?;
         Ok(Self::Ed25519(pk))
       }
       #[cfg(feature = "rsa-signature")]
       AlgorithmName::RsaV1_5Sha256 => {
         debug!("Read RSA public key");
         // read RsaPublicKey in PKCS#1 DER format
-        let pk = RsaPublicKey::from_pkcs1_der(bytes).map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
+        let pk = RsaPublicKey::from_pkcs1_der(bytes)
+          .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string().into()))?;
         Ok(Self::RsaV1_5Sha256(pkcs1v15::VerifyingKey::new(pk)))
       }
       #[cfg(feature = "rsa-signature")]
       AlgorithmName::RsaPssSha512 => {
         debug!("Read RSA-PSS public key");
         // read RsaPublicKey in PKCS#1 DER format
-        let pk = RsaPublicKey::from_pkcs1_der(bytes).map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
+        let pk = RsaPublicKey::from_pkcs1_der(bytes)
+          .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string().into()))?;
         Ok(Self::RsaPssSha512(pss::VerifyingKey::new(pk)))
       }
-      _ => Err(HttpSigError::ParsePublicKeyError("Unsupported algorithm".to_string())),
+      _ => Err(HttpSigError::ParsePublicKeyError(
+        "Unsupported algorithm".into(),
+      )),
     }
   }
 
   #[allow(dead_code)]
   /// Convert from pem string
   pub fn from_pem(alg: &AlgorithmName, pem: &str) -> HttpSigResult<Self> {
-    let (tag, doc) = Document::from_pem(pem).map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
+    let (tag, doc) = Document::from_pem(pem)
+      .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string().into()))?;
     if tag != "PUBLIC KEY" {
-      return Err(HttpSigError::ParsePublicKeyError("Invalid tag".to_string()));
+      return Err(HttpSigError::ParsePublicKeyError("Invalid tag".into()));
     };
 
-    let spki_ref = SubjectPublicKeyInfoRef::from_der(doc.as_bytes())
-      .map_err(|e| HttpSigError::ParsePublicKeyError(format!("Error decoding SubjectPublicKeyInfo: {e}").to_string()))?;
+    let spki_ref = SubjectPublicKeyInfoRef::from_der(doc.as_bytes()).map_err(|e| {
+      HttpSigError::ParsePublicKeyError(format!("Error decoding SubjectPublicKeyInfo: {e}").into())
+    })?;
 
     let pk_bytes = match spki_ref.algorithm.oid.to_string().as_ref() {
       // ec
@@ -309,45 +348,67 @@ impl PublicKey {
         let param = spki_ref
           .algorithm
           .parameters_oid()
-          .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
+          .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string().into()))?;
         let algorithm_name = match param.to_string().as_ref() {
           params_oids::Secp256r1 => AlgorithmName::EcdsaP256Sha256,
           params_oids::Secp384r1 => AlgorithmName::EcdsaP384Sha384,
-          _ => return Err(HttpSigError::ParsePublicKeyError("Unsupported curve".to_string())),
+          _ => {
+            return Err(HttpSigError::ParsePublicKeyError(
+              "Unsupported curve".into(),
+            ))
+          }
         };
         // assert algorithm
         if algorithm_name != *alg {
-          return Err(HttpSigError::ParsePublicKeyError("Algorithm mismatch".to_string()));
+          return Err(HttpSigError::ParsePublicKeyError(
+            "Algorithm mismatch".into(),
+          ));
         }
         spki_ref
           .subject_public_key
           .as_bytes()
-          .ok_or(HttpSigError::ParsePublicKeyError("Invalid public key".to_string()))?
+          .ok_or(HttpSigError::ParsePublicKeyError(
+            "Invalid public key".into(),
+          ))?
       }
       // ed25519
       algorithm_oids::Ed25519 => {
         // assert algorithm
         if AlgorithmName::Ed25519 != *alg {
-          return Err(HttpSigError::ParsePublicKeyError("Algorithm mismatch".to_string()));
+          return Err(HttpSigError::ParsePublicKeyError(
+            "Algorithm mismatch".into(),
+          ));
         }
         spki_ref
           .subject_public_key
           .as_bytes()
-          .ok_or(HttpSigError::ParsePublicKeyError("Invalid public key".to_string()))?
+          .ok_or(HttpSigError::ParsePublicKeyError(
+            "Invalid public key".into(),
+          ))?
       }
       // rsa
       #[cfg(feature = "rsa-signature")]
       algorithm_oids::rsaEncryption => {
         match alg {
           AlgorithmName::RsaV1_5Sha256 | AlgorithmName::RsaPssSha512 => {}
-          _ => return Err(HttpSigError::ParsePublicKeyError("Algorithm mismatch".to_string())),
+          _ => {
+            return Err(HttpSigError::ParsePublicKeyError(
+              "Algorithm mismatch".into(),
+            ))
+          }
         }
         spki_ref
           .subject_public_key
           .as_bytes()
-          .ok_or(HttpSigError::ParsePublicKeyError("Invalid public key".to_string()))?
+          .ok_or(HttpSigError::ParsePublicKeyError(
+            "Invalid public key".into(),
+          ))?
       }
-      _ => return Err(HttpSigError::ParsePublicKeyError("Unsupported algorithm".to_string())),
+      _ => {
+        return Err(HttpSigError::ParsePublicKeyError(
+          "Unsupported algorithm".into(),
+        ))
+      }
     };
     Self::from_bytes(alg, pk_bytes)
   }
@@ -360,43 +421,45 @@ impl super::VerifyingKey for PublicKey {
       Self::EcdsaP256Sha256(pk) => {
         debug!("Verify EcdsaP256Sha256");
         let signature = ecdsa::Signature::<NistP256>::from_bytes(signature.into())
-          .map_err(|e| HttpSigError::ParseSignatureError(e.to_string()))?;
+          .map_err(|e| HttpSigError::ParseSignatureError(e.to_string().into()))?;
         let vk = ecdsa::VerifyingKey::from(pk);
         let mut digest = <Sha256 as Digest>::new();
         digest.update(data);
         vk.verify_digest(digest, &signature)
-          .map_err(|e| HttpSigError::InvalidSignature(e.to_string()))
+          .map_err(|e| HttpSigError::InvalidSignature(e.to_string().into()))
       }
       Self::EcdsaP384Sha384(pk) => {
         debug!("Verify EcdsaP384Sha384");
         let signature = ecdsa::Signature::<NistP384>::from_bytes(signature.into())
-          .map_err(|e| HttpSigError::ParseSignatureError(e.to_string()))?;
+          .map_err(|e| HttpSigError::ParseSignatureError(e.to_string().into()))?;
         let vk = ecdsa::VerifyingKey::from(pk);
         let mut digest = <Sha384 as Digest>::new();
         digest.update(data);
         vk.verify_digest(digest, &signature)
-          .map_err(|e| HttpSigError::InvalidSignature(e.to_string()))
+          .map_err(|e| HttpSigError::InvalidSignature(e.to_string().into()))
       }
       Self::Ed25519(pk) => {
         debug!("Verify Ed25519");
-        let sig =
-          ed25519_compact::Signature::from_slice(signature).map_err(|e| HttpSigError::ParseSignatureError(e.to_string()))?;
+        let sig = ed25519_compact::Signature::from_slice(signature)
+          .map_err(|e| HttpSigError::ParseSignatureError(e.to_string().into()))?;
         pk.verify(data, &sig)
-          .map_err(|e| HttpSigError::InvalidSignature(e.to_string()))
+          .map_err(|e| HttpSigError::InvalidSignature(e.to_string().into()))
       }
       #[cfg(feature = "rsa-signature")]
       Self::RsaV1_5Sha256(pk) => {
         debug!("Verify RsaV1_5Sha256");
-        let sig = pkcs1v15::Signature::try_from(signature).map_err(|e| HttpSigError::ParseSignatureError(e.to_string()))?;
+        let sig = pkcs1v15::Signature::try_from(signature)
+          .map_err(|e| HttpSigError::ParseSignatureError(e.to_string().into()))?;
         pk.verify(data, &sig)
-          .map_err(|e| HttpSigError::InvalidSignature(e.to_string()))
+          .map_err(|e| HttpSigError::InvalidSignature(e.to_string().into()))
       }
       #[cfg(feature = "rsa-signature")]
       Self::RsaPssSha512(pk) => {
         debug!("Verify RsaPssSha512");
-        let sig = pss::Signature::try_from(signature).map_err(|e| HttpSigError::ParseSignatureError(e.to_string()))?;
+        let sig = pss::Signature::try_from(signature)
+          .map_err(|e| HttpSigError::ParseSignatureError(e.to_string().into()))?;
         pk.verify(data, &sig)
-          .map_err(|e| HttpSigError::InvalidSignature(e.to_string()))
+          .map_err(|e| HttpSigError::InvalidSignature(e.to_string().into()))
       }
     }
   }
@@ -540,7 +603,11 @@ tQIDAQAB
     let mut rng = rand_085::thread_rng();
     let es256_sk = p256::ecdsa::SigningKey::random(&mut rng);
     let es256_pk = es256_sk.verifying_key();
-    let sk = SecretKey::from_bytes(&AlgorithmName::EcdsaP256Sha256, es256_sk.to_bytes().as_ref()).unwrap();
+    let sk = SecretKey::from_bytes(
+      &AlgorithmName::EcdsaP256Sha256,
+      es256_sk.to_bytes().as_ref(),
+    )
+    .unwrap();
     assert!(matches!(sk, SecretKey::EcdsaP256Sha256(_)));
     let pk_bytes = es256_pk.as_affine().to_bytes();
     let pk = PublicKey::from_bytes(&AlgorithmName::EcdsaP256Sha256, pk_bytes.as_ref()).unwrap();

--- a/httpsig/src/crypto/asymmetric.rs
+++ b/httpsig/src/crypto/asymmetric.rs
@@ -107,9 +107,6 @@ impl SecretKey {
           pss::SigningKey::<rsa::sha2::Sha512>::new(sk),
         ))
       }
-      _ => Err(HttpSigError::ParsePrivateKeyError(
-        "Unsupported algorithm".into(),
-      )),
     }
   }
   /// parse der
@@ -332,9 +329,6 @@ impl PublicKey {
           .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string().into()))?;
         Ok(Self::RsaPssSha512(pss::VerifyingKey::new(pk)))
       }
-      _ => Err(HttpSigError::ParsePublicKeyError(
-        "Unsupported algorithm".into(),
-      )),
     }
   }
 

--- a/httpsig/src/crypto/asymmetric.rs
+++ b/httpsig/src/crypto/asymmetric.rs
@@ -7,6 +7,7 @@ use ecdsa::{
   elliptic_curve::{sec1::ToEncodedPoint, PublicKey as EcPublicKey, SecretKey as EcSecretKey},
   signature::{DigestSigner, DigestVerifier},
 };
+#[cfg(feature = "ed25519-signature")]
 use ed25519_compact::{PublicKey as Ed25519PublicKey, SecretKey as Ed25519SecretKey};
 use p256::NistP256;
 use p384::NistP384;
@@ -27,6 +28,7 @@ use rsa::{
 mod algorithm_oids {
   /// OID for `id-ecPublicKey`, if you're curious
   pub const EC: &str = "1.2.840.10045.2.1";
+  #[cfg(feature = "ed25519-signature")]
   /// OID for `id-Ed25519`, if you're curious
   pub const Ed25519: &str = "1.3.101.112";
   #[cfg(feature = "rsa-signature")]
@@ -51,6 +53,7 @@ pub enum SecretKey {
   EcdsaP384Sha384(EcSecretKey<NistP384>),
   /// ecdsa-p256-sha256
   EcdsaP256Sha256(EcSecretKey<NistP256>),
+  #[cfg(feature = "ed25519-signature")]
   /// ed25519
   Ed25519(Ed25519SecretKey),
   #[cfg(feature = "rsa-signature")]
@@ -76,6 +79,7 @@ impl SecretKey {
           .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string().into()))?;
         Ok(Self::EcdsaP384Sha384(sk))
       }
+      #[cfg(feature = "ed25519-signature")]
       AlgorithmName::Ed25519 => {
         debug!("Read Ed25519 private key");
         let mut seed = [0u8; 32];
@@ -143,6 +147,7 @@ impl SecretKey {
           .private_key;
         sk_bytes
       }
+      #[cfg(feature = "ed25519-signature")]
       // ed25519
       algorithm_oids::Ed25519 => {
         // assert algorithm
@@ -192,6 +197,7 @@ impl SecretKey {
     match &self {
       Self::EcdsaP256Sha256(key) => PublicKey::EcdsaP256Sha256(key.public_key()),
       Self::EcdsaP384Sha384(key) => PublicKey::EcdsaP384Sha384(key.public_key()),
+      #[cfg(feature = "ed25519-signature")]
       Self::Ed25519(key) => PublicKey::Ed25519(key.public_key()),
       #[cfg(feature = "rsa-signature")]
       Self::RsaV1_5Sha256(key) => PublicKey::RsaV1_5Sha256(key.verifying_key()),
@@ -221,6 +227,7 @@ impl super::SigningKey for SecretKey {
         let sig: ecdsa::Signature<NistP384> = sk.sign_digest(digest);
         Ok(sig.to_bytes().to_vec())
       }
+      #[cfg(feature = "ed25519-signature")]
       Self::Ed25519(sk) => {
         debug!("Sign Ed25519");
         let sig = sk.sign(data, Some(ed25519_compact::Noise::default()));
@@ -275,6 +282,7 @@ pub enum PublicKey {
   EcdsaP256Sha256(EcPublicKey<NistP256>),
   /// ecdsa-p384-sha384
   EcdsaP384Sha384(EcPublicKey<NistP384>),
+  #[cfg(feature = "ed25519-signature")]
   /// ed25519
   Ed25519(Ed25519PublicKey),
   #[cfg(feature = "rsa-signature")]
@@ -301,6 +309,7 @@ impl PublicKey {
           .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string().into()))?;
         Ok(Self::EcdsaP384Sha384(pk))
       }
+      #[cfg(feature = "ed25519-signature")]
       AlgorithmName::Ed25519 => {
         debug!("Read Ed25519 public key");
         let pk = ed25519_compact::PublicKey::from_slice(bytes)
@@ -371,6 +380,7 @@ impl PublicKey {
             "Invalid public key".into(),
           ))?
       }
+      #[cfg(feature = "ed25519-signature")]
       // ed25519
       algorithm_oids::Ed25519 => {
         // assert algorithm
@@ -438,6 +448,7 @@ impl super::VerifyingKey for PublicKey {
         vk.verify_digest(digest, &signature)
           .map_err(|e| HttpSigError::InvalidSignature(e.to_string().into()))
       }
+      #[cfg(feature = "ed25519-signature")]
       Self::Ed25519(pk) => {
         debug!("Verify Ed25519");
         let sig = ed25519_compact::Signature::from_slice(signature)
@@ -474,6 +485,7 @@ impl super::VerifyingKey for PublicKey {
     let bytes = match self {
       Self::EcdsaP256Sha256(vk) => vk.to_encoded_point(true).as_bytes().to_vec(),
       Self::EcdsaP384Sha384(vk) => vk.to_encoded_point(true).as_bytes().to_vec(),
+      #[cfg(feature = "ed25519-signature")]
       Self::Ed25519(vk) => vk.as_ref().to_vec(),
       #[cfg(feature = "rsa-signature")]
       Self::RsaV1_5Sha256(vk) => vk
@@ -499,6 +511,7 @@ impl super::VerifyingKey for PublicKey {
     match self {
       Self::EcdsaP256Sha256(_) => AlgorithmName::EcdsaP256Sha256,
       Self::EcdsaP384Sha384(_) => AlgorithmName::EcdsaP384Sha384,
+      #[cfg(feature = "ed25519-signature")]
       Self::Ed25519(_) => AlgorithmName::Ed25519,
       #[cfg(feature = "rsa-signature")]
       Self::RsaV1_5Sha256(_) => AlgorithmName::RsaV1_5Sha256,
@@ -540,10 +553,12 @@ UfpGAyh8CK7iBfXwj2sAB9rZ27nN8RM0
 -----END PUBLIC KEY-----
 "##;
 
+  #[cfg(feature = "ed25519-signature")]
   const EDDSA_SECRET_KEY: &str = r##"-----BEGIN PRIVATE KEY-----
 MC4CAQAwBQYDK2VwBCIEIDSHAE++q1BP7T8tk+mJtS+hLf81B0o6CFyWgucDFN/C
 -----END PRIVATE KEY-----
 "##;
+  #[cfg(feature = "ed25519-signature")]
   const EDDSA_PUBLIC_KEY: &str = r##"-----BEGIN PUBLIC KEY-----
 MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
 -----END PUBLIC KEY-----
@@ -592,13 +607,16 @@ tQIDAQAB
 
   #[test]
   fn test_from_bytes() {
-    let ed25519_kp = ed25519_compact::KeyPair::from_seed(ed25519_compact::Seed::default());
-    let ed25519_sk = ed25519_kp.sk.seed().to_vec();
-    let ed25519_pk = ed25519_kp.pk.as_ref();
-    let sk = SecretKey::from_bytes(&AlgorithmName::Ed25519, &ed25519_sk).unwrap();
-    assert!(matches!(sk, SecretKey::Ed25519(_)));
-    let pk = PublicKey::from_bytes(&AlgorithmName::Ed25519, ed25519_pk).unwrap();
-    assert!(matches!(pk, PublicKey::Ed25519(_)));
+    #[cfg(feature = "ed25519-signature")]
+    {
+      let ed25519_kp = ed25519_compact::KeyPair::from_seed(ed25519_compact::Seed::default());
+      let ed25519_sk = ed25519_kp.sk.seed().to_vec();
+      let ed25519_pk = ed25519_kp.pk.as_ref();
+      let sk = SecretKey::from_bytes(&AlgorithmName::Ed25519, &ed25519_sk).unwrap();
+      assert!(matches!(sk, SecretKey::Ed25519(_)));
+      let pk = PublicKey::from_bytes(&AlgorithmName::Ed25519, ed25519_pk).unwrap();
+      assert!(matches!(pk, PublicKey::Ed25519(_)));
+    }
 
     let mut rng = rand_085::thread_rng();
     let es256_sk = p256::ecdsa::SigningKey::random(&mut rng);
@@ -626,10 +644,13 @@ tQIDAQAB
     let pk = PublicKey::from_pem(&AlgorithmName::EcdsaP384Sha384, P384_PUBLIC_KEY).unwrap();
     assert!(matches!(pk, PublicKey::EcdsaP384Sha384(_)));
 
-    let sk = SecretKey::from_pem(&AlgorithmName::Ed25519, EDDSA_SECRET_KEY).unwrap();
-    assert!(matches!(sk, SecretKey::Ed25519(_)));
-    let pk = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
-    assert!(matches!(pk, PublicKey::Ed25519(_)));
+    #[cfg(feature = "ed25519-signature")]
+    {
+      let sk = SecretKey::from_pem(&AlgorithmName::Ed25519, EDDSA_SECRET_KEY).unwrap();
+      assert!(matches!(sk, SecretKey::Ed25519(_)));
+      let pk = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
+      assert!(matches!(pk, PublicKey::Ed25519(_)));
+    }
   }
 
   #[cfg(feature = "rsa-signature")]
@@ -663,12 +684,15 @@ tQIDAQAB
     pk.verify(data, &signature).unwrap();
     assert!(pk.verify(b"hello", &signature).is_err());
 
-    let sk = SecretKey::from_pem(&AlgorithmName::Ed25519, EDDSA_SECRET_KEY).unwrap();
-    let pk = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
-    let data = b"hello world";
-    let signature = sk.sign(data).unwrap();
-    pk.verify(data, &signature).unwrap();
-    assert!(pk.verify(b"hello", &signature).is_err());
+    #[cfg(feature = "ed25519-signature")]
+    {
+      let sk = SecretKey::from_pem(&AlgorithmName::Ed25519, EDDSA_SECRET_KEY).unwrap();
+      let pk = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
+      let data = b"hello world";
+      let signature = sk.sign(data).unwrap();
+      pk.verify(data, &signature).unwrap();
+      assert!(pk.verify(b"hello", &signature).is_err());
+    }
   }
 
   #[cfg(feature = "rsa-signature")]
@@ -703,10 +727,13 @@ tQIDAQAB
     assert_eq!(sk.public_key().key_id(), pk.key_id());
     assert_eq!(pk.key_id(), "JluSJKLaQsbGcgg1Ves4FfP/Kf7qS11RT88TvU0eNSo=");
 
-    let sk = SecretKey::from_pem(&AlgorithmName::Ed25519, EDDSA_SECRET_KEY)?;
-    let pk = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY)?;
-    assert_eq!(sk.public_key().key_id(), pk.key_id());
-    assert_eq!(pk.key_id(), "gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=");
+    #[cfg(feature = "ed25519-signature")]
+    {
+      let sk = SecretKey::from_pem(&AlgorithmName::Ed25519, EDDSA_SECRET_KEY)?;
+      let pk = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY)?;
+      assert_eq!(sk.public_key().key_id(), pk.key_id());
+      assert_eq!(pk.key_id(), "gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=");
+    }
     Ok(())
   }
 

--- a/httpsig/src/crypto/asymmetric.rs
+++ b/httpsig/src/crypto/asymmetric.rs
@@ -3,29 +3,58 @@ use crate::{
   error::{HttpSigError, HttpSigResult},
   trace::*,
 };
+#[cfg(all(
+  feature = "key-id",
+  any(
+    feature = "ecdsa-p256-sha256-signature",
+    feature = "ecdsa-p384-sha384-signature"
+  )
+))]
+use ecdsa::elliptic_curve::sec1::ToEncodedPoint;
+#[cfg(any(
+  feature = "ecdsa-p256-sha256-signature",
+  feature = "ecdsa-p384-sha384-signature"
+))]
 use ecdsa::{
-  elliptic_curve::{sec1::ToEncodedPoint, PublicKey as EcPublicKey, SecretKey as EcSecretKey},
+  elliptic_curve::{PublicKey as EcPublicKey, SecretKey as EcSecretKey},
   signature::{DigestSigner, DigestVerifier},
 };
 #[cfg(feature = "ed25519-signature")]
 use ed25519_compact::{PublicKey as Ed25519PublicKey, SecretKey as Ed25519SecretKey};
+#[cfg(feature = "ecdsa-p256-sha256-signature")]
 use p256::NistP256;
+#[cfg(feature = "ecdsa-p384-sha384-signature")]
 use p384::NistP384;
-use pkcs8::{der::Decode, Document, PrivateKeyInfo};
-use sha2::{Digest, Sha256, Sha384};
-use spki::SubjectPublicKeyInfoRef;
+#[cfg(feature = "pem")]
+use pkcs8::Document;
+#[cfg(feature = "der")]
+use pkcs8::{der::Decode, PrivateKeyInfo};
+#[cfg(any(
+  feature = "ecdsa-p256-sha256-signature",
+  feature = "ecdsa-p384-sha384-signature",
+  feature = "key-id"
+))]
+use sha2::Digest;
+
+#[cfg(all(feature = "rsa-signature", feature = "pem"))]
+use rsa::pkcs1::EncodeRsaPublicKey;
 
 #[cfg(feature = "rsa-signature")]
 use rsa::{
-  pkcs1::{DecodeRsaPrivateKey, DecodeRsaPublicKey, EncodeRsaPublicKey},
+  pkcs1::{DecodeRsaPrivateKey, DecodeRsaPublicKey},
   pkcs1v15, pss,
   signature::{Keypair, RandomizedSigner, SignatureEncoding, Verifier},
   RsaPrivateKey, RsaPublicKey,
 };
 
+#[cfg(any(feature = "der", feature = "pem"))]
 #[allow(non_upper_case_globals, dead_code)]
 /// Algorithm OIDs
 mod algorithm_oids {
+  #[cfg(any(
+    feature = "ecdsa-p256-sha256-signature",
+    feature = "ecdsa-p384-sha384-signature"
+  ))]
   /// OID for `id-ecPublicKey`, if you're curious
   pub const EC: &str = "1.2.840.10045.2.1";
   #[cfg(feature = "ed25519-signature")]
@@ -35,11 +64,14 @@ mod algorithm_oids {
   /// OID for `id-rsaEncryption`, if you're curious
   pub const rsaEncryption: &str = "1.2.840.113549.1.1.1";
 }
+#[cfg(any(feature = "der", feature = "pem"))]
 #[allow(non_upper_case_globals, dead_code)]
 /// Params OIDs
 mod params_oids {
+  #[cfg(feature = "ecdsa-p256-sha256-signature")]
   // OID for the NIST P-256 elliptic curve.
   pub const Secp256r1: &str = "1.2.840.10045.3.1.7";
+  #[cfg(feature = "ecdsa-p384-sha384-signature")]
   // OID for the NIST P-384 elliptic curve.
   pub const Secp384r1: &str = "1.3.132.0.34";
 }
@@ -49,8 +81,10 @@ mod params_oids {
 /// Secret key for http signature
 /// Name conventions follow [Section-6.2.2, RFC9421](https://datatracker.ietf.org/doc/html/rfc9421#section-6.2.2)
 pub enum SecretKey {
+  #[cfg(feature = "ecdsa-p384-sha384-signature")]
   /// ecdsa-p384-sha384
   EcdsaP384Sha384(EcSecretKey<NistP384>),
+  #[cfg(feature = "ecdsa-p256-sha256-signature")]
   /// ecdsa-p256-sha256
   EcdsaP256Sha256(EcSecretKey<NistP256>),
   #[cfg(feature = "ed25519-signature")]
@@ -67,18 +101,24 @@ impl SecretKey {
   /// from plain bytes
   pub fn from_bytes(alg: &AlgorithmName, bytes: &[u8]) -> HttpSigResult<Self> {
     match alg {
+      #[cfg(feature = "ecdsa-p256-sha256-signature")]
       AlgorithmName::EcdsaP256Sha256 => {
         debug!("Read P256 private key");
         let sk = EcSecretKey::from_bytes(bytes.into())
           .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string().into()))?;
         Ok(Self::EcdsaP256Sha256(sk))
       }
+      #[cfg(feature = "ecdsa-p384-sha384-signature")]
       AlgorithmName::EcdsaP384Sha384 => {
         debug!("Read P384 private key");
         let sk = EcSecretKey::from_bytes(bytes.into())
           .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string().into()))?;
         Ok(Self::EcdsaP384Sha384(sk))
       }
+      #[cfg(feature = "hmac-sha256-signature")]
+      AlgorithmName::HmacSha256 => Err(HttpSigError::ParsePrivateKeyError(
+        "Unsupported algorithm".into(),
+      )),
       #[cfg(feature = "ed25519-signature")]
       AlgorithmName::Ed25519 => {
         debug!("Read Ed25519 private key");
@@ -109,6 +149,7 @@ impl SecretKey {
       }
     }
   }
+  #[cfg(feature = "der")]
   /// parse der
   /// Derive secret key from der bytes
   pub fn from_der(alg: &AlgorithmName, der: &[u8]) -> HttpSigResult<Self> {
@@ -116,6 +157,10 @@ impl SecretKey {
       .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string().into()))?;
 
     let sk_bytes = match pki.algorithm.oid.to_string().as_ref() {
+      #[cfg(any(
+        feature = "ecdsa-p256-sha256-signature",
+        feature = "ecdsa-p384-sha384-signature"
+      ))]
       // ec
       algorithm_oids::EC => {
         let param = pki
@@ -123,7 +168,9 @@ impl SecretKey {
           .parameters_oid()
           .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string().into()))?;
         let algorithm_name = match param.to_string().as_ref() {
+          #[cfg(feature = "ecdsa-p256-sha256-signature")]
           params_oids::Secp256r1 => AlgorithmName::EcdsaP256Sha256,
+          #[cfg(feature = "ecdsa-p384-sha384-signature")]
           params_oids::Secp384r1 => AlgorithmName::EcdsaP384Sha384,
           _ => {
             return Err(HttpSigError::ParsePrivateKeyError(
@@ -179,6 +226,7 @@ impl SecretKey {
     Ok(sk)
   }
 
+  #[cfg(feature = "pem")]
   /// Derive secret key from pem string
   pub fn from_pem(alg: &AlgorithmName, pem: &str) -> HttpSigResult<Self> {
     let (tag, doc) = Document::from_pem(pem)
@@ -192,7 +240,9 @@ impl SecretKey {
   /// Get public key from secret key
   pub fn public_key(&self) -> PublicKey {
     match &self {
+      #[cfg(feature = "ecdsa-p256-sha256-signature")]
       Self::EcdsaP256Sha256(key) => PublicKey::EcdsaP256Sha256(key.public_key()),
+      #[cfg(feature = "ecdsa-p384-sha384-signature")]
       Self::EcdsaP384Sha384(key) => PublicKey::EcdsaP384Sha384(key.public_key()),
       #[cfg(feature = "ed25519-signature")]
       Self::Ed25519(key) => PublicKey::Ed25519(key.public_key()),
@@ -208,18 +258,20 @@ impl super::SigningKey for SecretKey {
   /// Sign data
   fn sign(&self, data: &[u8]) -> HttpSigResult<Vec<u8>> {
     match &self {
+      #[cfg(feature = "ecdsa-p256-sha256-signature")]
       Self::EcdsaP256Sha256(sk) => {
         debug!("Sign EcdsaP256Sha256");
         let sk = ecdsa::SigningKey::from(sk);
-        let mut digest = <Sha256 as Digest>::new();
+        let mut digest = <sha2::Sha256 as sha2::Digest>::new();
         digest.update(data);
         let sig: ecdsa::Signature<NistP256> = sk.sign_digest(digest);
         Ok(sig.to_bytes().to_vec())
       }
+      #[cfg(feature = "ecdsa-p384-sha384-signature")]
       Self::EcdsaP384Sha384(sk) => {
         debug!("Sign EcdsaP384Sha384");
         let sk = ecdsa::SigningKey::from(sk);
-        let mut digest = <Sha384 as Digest>::new();
+        let mut digest = <sha2::Sha384 as sha2::Digest>::new();
         digest.update(data);
         let sig: ecdsa::Signature<NistP384> = sk.sign_digest(digest);
         Ok(sig.to_bytes().to_vec())
@@ -245,6 +297,7 @@ impl super::SigningKey for SecretKey {
     }
   }
 
+  #[cfg(feature = "key-id")]
   fn key_id(&self) -> String {
     use super::VerifyingKey;
     self.public_key().key_id()
@@ -261,6 +314,7 @@ impl super::VerifyingKey for SecretKey {
     self.public_key().verify(data, signature)
   }
 
+  #[cfg(feature = "key-id")]
   fn key_id(&self) -> String {
     self.public_key().key_id()
   }
@@ -275,8 +329,10 @@ impl super::VerifyingKey for SecretKey {
 /// Public key for http signature, only for asymmetric algorithm
 /// Name conventions follow [Section 6.2.2, RFC9421](https://datatracker.ietf.org/doc/html/rfc9421#section-6.2.2)
 pub enum PublicKey {
+  #[cfg(feature = "ecdsa-p256-sha256-signature")]
   /// ecdsa-p256-sha256
   EcdsaP256Sha256(EcPublicKey<NistP256>),
+  #[cfg(feature = "ecdsa-p384-sha384-signature")]
   /// ecdsa-p384-sha384
   EcdsaP384Sha384(EcPublicKey<NistP384>),
   #[cfg(feature = "ed25519-signature")]
@@ -294,12 +350,14 @@ impl PublicKey {
   /// from plain bytes
   pub fn from_bytes(alg: &AlgorithmName, bytes: &[u8]) -> HttpSigResult<Self> {
     match alg {
+      #[cfg(feature = "ecdsa-p256-sha256-signature")]
       AlgorithmName::EcdsaP256Sha256 => {
         debug!("Read P256 public key");
         let pk = EcPublicKey::from_sec1_bytes(bytes)
           .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string().into()))?;
         Ok(Self::EcdsaP256Sha256(pk))
       }
+      #[cfg(feature = "ecdsa-p384-sha384-signature")]
       AlgorithmName::EcdsaP384Sha384 => {
         debug!("Read P384 public key");
         let pk = EcPublicKey::from_sec1_bytes(bytes)
@@ -313,6 +371,10 @@ impl PublicKey {
           .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string().into()))?;
         Ok(Self::Ed25519(pk))
       }
+      #[cfg(feature = "hmac-sha256-signature")]
+      AlgorithmName::HmacSha256 => Err(HttpSigError::ParsePrivateKeyError(
+        "Unsupported algorithm".into(),
+      )),
       #[cfg(feature = "rsa-signature")]
       AlgorithmName::RsaV1_5Sha256 => {
         debug!("Read RSA public key");
@@ -332,6 +394,7 @@ impl PublicKey {
     }
   }
 
+  #[cfg(feature = "pem")]
   #[allow(dead_code)]
   /// Convert from pem string
   pub fn from_pem(alg: &AlgorithmName, pem: &str) -> HttpSigResult<Self> {
@@ -341,11 +404,15 @@ impl PublicKey {
       return Err(HttpSigError::ParsePublicKeyError("Invalid tag".into()));
     };
 
-    let spki_ref = SubjectPublicKeyInfoRef::from_der(doc.as_bytes()).map_err(|e| {
+    let spki_ref = spki::SubjectPublicKeyInfoRef::from_der(doc.as_bytes()).map_err(|e| {
       HttpSigError::ParsePublicKeyError(format!("Error decoding SubjectPublicKeyInfo: {e}").into())
     })?;
 
     let pk_bytes = match spki_ref.algorithm.oid.to_string().as_ref() {
+      #[cfg(any(
+        feature = "ecdsa-p256-sha256-signature",
+        feature = "ecdsa-p384-sha384-signature"
+      ))]
       // ec
       algorithm_oids::EC => {
         let param = spki_ref
@@ -353,7 +420,9 @@ impl PublicKey {
           .parameters_oid()
           .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string().into()))?;
         let algorithm_name = match param.to_string().as_ref() {
+          #[cfg(feature = "ecdsa-p256-sha256-signature")]
           params_oids::Secp256r1 => AlgorithmName::EcdsaP256Sha256,
+          #[cfg(feature = "ecdsa-p384-sha384-signature")]
           params_oids::Secp384r1 => AlgorithmName::EcdsaP384Sha384,
           _ => {
             return Err(HttpSigError::ParsePublicKeyError(
@@ -422,22 +491,24 @@ impl super::VerifyingKey for PublicKey {
   /// Verify signature
   fn verify(&self, data: &[u8], signature: &[u8]) -> HttpSigResult<()> {
     match self {
+      #[cfg(feature = "ecdsa-p256-sha256-signature")]
       Self::EcdsaP256Sha256(pk) => {
         debug!("Verify EcdsaP256Sha256");
         let signature = ecdsa::Signature::<NistP256>::from_bytes(signature.into())
           .map_err(|e| HttpSigError::ParseSignatureError(e.to_string().into()))?;
         let vk = ecdsa::VerifyingKey::from(pk);
-        let mut digest = <Sha256 as Digest>::new();
+        let mut digest = <sha2::Sha256 as Digest>::new();
         digest.update(data);
         vk.verify_digest(digest, &signature)
           .map_err(|e| HttpSigError::InvalidSignature(e.to_string().into()))
       }
+      #[cfg(feature = "ecdsa-p384-sha384-signature")]
       Self::EcdsaP384Sha384(pk) => {
         debug!("Verify EcdsaP384Sha384");
         let signature = ecdsa::Signature::<NistP384>::from_bytes(signature.into())
           .map_err(|e| HttpSigError::ParseSignatureError(e.to_string().into()))?;
         let vk = ecdsa::VerifyingKey::from(pk);
-        let mut digest = <Sha384 as Digest>::new();
+        let mut digest = <sha2::Sha384 as Digest>::new();
         digest.update(data);
         vk.verify_digest(digest, &signature)
           .map_err(|e| HttpSigError::InvalidSignature(e.to_string().into()))
@@ -469,6 +540,7 @@ impl super::VerifyingKey for PublicKey {
     }
   }
 
+  #[cfg(feature = "key-id")]
   /// Create key id, created by SHA-256 hash of the public key bytes, then encoded in base64
   /// - For ECDSA keys, use the uncompressed SEC1 encoding of the public key point as the byte representation.
   /// - For Ed25519 keys, use the raw 32-byte public key.
@@ -477,7 +549,9 @@ impl super::VerifyingKey for PublicKey {
     use base64::{engine::general_purpose, Engine as _};
 
     let bytes = match self {
+      #[cfg(feature = "ecdsa-p256-sha256-signature")]
       Self::EcdsaP256Sha256(vk) => vk.to_encoded_point(true).as_bytes().to_vec(),
+      #[cfg(feature = "ecdsa-p384-sha384-signature")]
       Self::EcdsaP384Sha384(vk) => vk.to_encoded_point(true).as_bytes().to_vec(),
       #[cfg(feature = "ed25519-signature")]
       Self::Ed25519(vk) => vk.as_ref().to_vec(),
@@ -494,7 +568,7 @@ impl super::VerifyingKey for PublicKey {
         .map(|der| der.as_bytes().to_vec())
         .unwrap_or(b"rsa-der-serialization-failed".to_vec()),
     };
-    let mut hasher = <Sha256 as Digest>::new();
+    let mut hasher = <sha2::Sha256 as Digest>::new();
     hasher.update(&bytes);
     let hash = hasher.finalize();
     general_purpose::STANDARD.encode(hash)
@@ -503,7 +577,9 @@ impl super::VerifyingKey for PublicKey {
   /// Get the algorithm name
   fn alg(&self) -> AlgorithmName {
     match self {
+      #[cfg(feature = "ecdsa-p256-sha256-signature")]
       Self::EcdsaP256Sha256(_) => AlgorithmName::EcdsaP256Sha256,
+      #[cfg(feature = "ecdsa-p384-sha384-signature")]
       Self::EcdsaP384Sha384(_) => AlgorithmName::EcdsaP384Sha384,
       #[cfg(feature = "ed25519-signature")]
       Self::Ed25519(_) => AlgorithmName::Ed25519,
@@ -517,22 +593,26 @@ impl super::VerifyingKey for PublicKey {
 
 #[cfg(test)]
 mod tests {
+  #[cfg(feature = "ecdsa-p256-sha256-signature")]
   use p256::elliptic_curve::group::GroupEncoding;
 
   use super::*;
   use std::matches;
 
+  #[cfg(feature = "ecdsa-p256-sha256-signature")]
   const P256_SECRET_KEY: &str = r##"-----BEGIN PRIVATE KEY-----
 MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgv7zxW56ojrWwmSo1
 4uOdbVhUfj9Jd+5aZIB9u8gtWnihRANCAARGYsMe0CT6pIypwRvoJlLNs4+cTh2K
 L7fUNb5i6WbKxkpAoO+6T3pMBG5Yw7+8NuGTvvtrZAXduA2giPxQ8zCf
 -----END PRIVATE KEY-----
 "##;
+  #[cfg(feature = "ecdsa-p256-sha256-signature")]
   const P256_PUBLIC_KEY: &str = r##"-----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERmLDHtAk+qSMqcEb6CZSzbOPnE4d
 ii+31DW+YulmysZKQKDvuk96TARuWMO/vDbhk777a2QF3bgNoIj8UPMwnw==
 -----END PUBLIC KEY-----
 "##;
+  #[cfg(feature = "ecdsa-p384-sha384-signature")]
   const P384_SECRET_KEY: &str = r##"-----BEGIN PRIVATE KEY-----
 MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDCPYbeLLlIQKUzVyVGH
 MeuFp/9o2Lr+4GrI3bsbHuViMMceiuM+8xqzFCSm4Ltl5UyhZANiAARKg3yM+Ltx
@@ -540,6 +620,7 @@ n4ZptF3hI6Q167crEtPRklCEsRTyWUqy+VrrnM5LU/+fqxVbyniBZHd4vmQVYtjF
 xsv8P3DpjvpKJZqFfVdIr2ZR+kYDKHwIruIF9fCPawAH2tnbuc3xEzQ=
 -----END PRIVATE KEY-----
 "##;
+  #[cfg(feature = "ecdsa-p384-sha384-signature")]
   const P384_PUBLIC_KEY: &str = r##"-----BEGIN PUBLIC KEY-----
 MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAESoN8jPi7cZ+GabRd4SOkNeu3KxLT0ZJQ
 hLEU8llKsvla65zOS1P/n6sVW8p4gWR3eL5kFWLYxcbL/D9w6Y76SiWahX1XSK9m
@@ -612,31 +693,40 @@ tQIDAQAB
       assert!(matches!(pk, PublicKey::Ed25519(_)));
     }
 
-    let mut rng = rand_085::thread_rng();
-    let es256_sk = p256::ecdsa::SigningKey::random(&mut rng);
-    let es256_pk = es256_sk.verifying_key();
-    let sk = SecretKey::from_bytes(
-      &AlgorithmName::EcdsaP256Sha256,
-      es256_sk.to_bytes().as_ref(),
-    )
-    .unwrap();
-    assert!(matches!(sk, SecretKey::EcdsaP256Sha256(_)));
-    let pk_bytes = es256_pk.as_affine().to_bytes();
-    let pk = PublicKey::from_bytes(&AlgorithmName::EcdsaP256Sha256, pk_bytes.as_ref()).unwrap();
-    assert!(matches!(pk, PublicKey::EcdsaP256Sha256(_)));
+    #[cfg(feature = "ecdsa-p256-sha256-signature")]
+    {
+      let mut rng = rand_085::thread_rng();
+      let es256_sk = p256::ecdsa::SigningKey::random(&mut rng);
+      let es256_pk = es256_sk.verifying_key();
+      let sk = SecretKey::from_bytes(
+        &AlgorithmName::EcdsaP256Sha256,
+        es256_sk.to_bytes().as_ref(),
+      )
+      .unwrap();
+      assert!(matches!(sk, SecretKey::EcdsaP256Sha256(_)));
+      let pk_bytes = es256_pk.as_affine().to_bytes();
+      let pk = PublicKey::from_bytes(&AlgorithmName::EcdsaP256Sha256, pk_bytes.as_ref()).unwrap();
+      assert!(matches!(pk, PublicKey::EcdsaP256Sha256(_)));
+    }
   }
 
   #[test]
   fn test_from_pem() {
-    let sk = SecretKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_SECRET_KEY).unwrap();
-    assert!(matches!(sk, SecretKey::EcdsaP256Sha256(_)));
-    let pk = PublicKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_PUBLIC_KEY).unwrap();
-    assert!(matches!(pk, PublicKey::EcdsaP256Sha256(_)));
+    #[cfg(feature = "ecdsa-p256-sha256-signature")]
+    {
+      let sk = SecretKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_SECRET_KEY).unwrap();
+      assert!(matches!(sk, SecretKey::EcdsaP256Sha256(_)));
+      let pk = PublicKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_PUBLIC_KEY).unwrap();
+      assert!(matches!(pk, PublicKey::EcdsaP256Sha256(_)));
+    }
 
-    let sk = SecretKey::from_pem(&AlgorithmName::EcdsaP384Sha384, P384_SECRET_KEY).unwrap();
-    assert!(matches!(sk, SecretKey::EcdsaP384Sha384(_)));
-    let pk = PublicKey::from_pem(&AlgorithmName::EcdsaP384Sha384, P384_PUBLIC_KEY).unwrap();
-    assert!(matches!(pk, PublicKey::EcdsaP384Sha384(_)));
+    #[cfg(feature = "ecdsa-p384-sha384-signature")]
+    {
+      let sk = SecretKey::from_pem(&AlgorithmName::EcdsaP384Sha384, P384_SECRET_KEY).unwrap();
+      assert!(matches!(sk, SecretKey::EcdsaP384Sha384(_)));
+      let pk = PublicKey::from_pem(&AlgorithmName::EcdsaP384Sha384, P384_PUBLIC_KEY).unwrap();
+      assert!(matches!(pk, PublicKey::EcdsaP384Sha384(_)));
+    }
 
     #[cfg(feature = "ed25519-signature")]
     {
@@ -664,19 +754,25 @@ tQIDAQAB
   #[test]
   fn test_sign_verify() {
     use super::super::{SigningKey, VerifyingKey};
-    let sk = SecretKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_SECRET_KEY).unwrap();
-    let pk = PublicKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_PUBLIC_KEY).unwrap();
-    let data = b"hello world";
-    let signature = sk.sign(data).unwrap();
-    pk.verify(data, &signature).unwrap();
-    assert!(pk.verify(b"hello", &signature).is_err());
+    #[cfg(feature = "ecdsa-p256-sha256-signature")]
+    {
+      let sk = SecretKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_SECRET_KEY).unwrap();
+      let pk = PublicKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_PUBLIC_KEY).unwrap();
+      let data = b"hello world";
+      let signature = sk.sign(data).unwrap();
+      pk.verify(data, &signature).unwrap();
+      assert!(pk.verify(b"hello", &signature).is_err());
+    }
 
-    let sk = SecretKey::from_pem(&AlgorithmName::EcdsaP384Sha384, P384_SECRET_KEY).unwrap();
-    let pk = PublicKey::from_pem(&AlgorithmName::EcdsaP384Sha384, P384_PUBLIC_KEY).unwrap();
-    let data = b"hello world";
-    let signature = sk.sign(data).unwrap();
-    pk.verify(data, &signature).unwrap();
-    assert!(pk.verify(b"hello", &signature).is_err());
+    #[cfg(feature = "ecdsa-p384-sha384-signature")]
+    {
+      let sk = SecretKey::from_pem(&AlgorithmName::EcdsaP384Sha384, P384_SECRET_KEY).unwrap();
+      let pk = PublicKey::from_pem(&AlgorithmName::EcdsaP384Sha384, P384_PUBLIC_KEY).unwrap();
+      let data = b"hello world";
+      let signature = sk.sign(data).unwrap();
+      pk.verify(data, &signature).unwrap();
+      assert!(pk.verify(b"hello", &signature).is_err());
+    }
 
     #[cfg(feature = "ed25519-signature")]
     {
@@ -711,15 +807,21 @@ tQIDAQAB
   #[test]
   fn test_kid() -> HttpSigResult<()> {
     use super::super::VerifyingKey;
-    let sk = SecretKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_SECRET_KEY)?;
-    let pk = PublicKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_PUBLIC_KEY)?;
-    assert_eq!(sk.public_key().key_id(), pk.key_id());
-    assert_eq!(pk.key_id(), "k34r3Nqfak67bhJSXTjTRo5tCIr1Bsre1cPoJ3LJ9xE=");
+    #[cfg(feature = "ecdsa-p256-sha256-signature")]
+    {
+      let sk = SecretKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_SECRET_KEY)?;
+      let pk = PublicKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_PUBLIC_KEY)?;
+      assert_eq!(sk.public_key().key_id(), pk.key_id());
+      assert_eq!(pk.key_id(), "k34r3Nqfak67bhJSXTjTRo5tCIr1Bsre1cPoJ3LJ9xE=");
+    }
 
-    let sk = SecretKey::from_pem(&AlgorithmName::EcdsaP384Sha384, P384_SECRET_KEY)?;
-    let pk = PublicKey::from_pem(&AlgorithmName::EcdsaP384Sha384, P384_PUBLIC_KEY)?;
-    assert_eq!(sk.public_key().key_id(), pk.key_id());
-    assert_eq!(pk.key_id(), "JluSJKLaQsbGcgg1Ves4FfP/Kf7qS11RT88TvU0eNSo=");
+    #[cfg(feature = "ecdsa-p384-sha384-signature")]
+    {
+      let sk = SecretKey::from_pem(&AlgorithmName::EcdsaP384Sha384, P384_SECRET_KEY)?;
+      let pk = PublicKey::from_pem(&AlgorithmName::EcdsaP384Sha384, P384_PUBLIC_KEY)?;
+      assert_eq!(sk.public_key().key_id(), pk.key_id());
+      assert_eq!(pk.key_id(), "JluSJKLaQsbGcgg1Ves4FfP/Kf7qS11RT88TvU0eNSo=");
+    }
 
     #[cfg(feature = "ed25519-signature")]
     {

--- a/httpsig/src/crypto/mod.rs
+++ b/httpsig/src/crypto/mod.rs
@@ -1,16 +1,34 @@
+#[cfg(any(
+  feature = "ed25519-signature",
+  feature = "ecdsa-p256-sha256-signature",
+  feature = "ecdsa-p384-sha384-signature",
+  feature = "rsa-signature"
+))]
 mod asymmetric;
+#[cfg(feature = "hmac-sha256-signature")]
 mod symmetric;
 
 use crate::error::{HttpSigError, HttpSigResult};
 
+#[cfg(any(
+  feature = "ed25519-signature",
+  feature = "ecdsa-p256-sha256-signature",
+  feature = "ecdsa-p384-sha384-signature",
+  feature = "rsa-signature"
+))]
 pub use asymmetric::{PublicKey, SecretKey};
+#[cfg(feature = "hmac-sha256-signature")]
 pub use symmetric::SharedKey;
 
 #[derive(Debug, PartialEq, Eq)]
 /// Algorithm names
 pub enum AlgorithmName {
+  #[cfg(feature = "hmac-sha256-signature")]
   HmacSha256,
+  #[cfg(feature = "ecdsa-p256-sha256-signature")]
+  /// ecdsa-p256-sha256
   EcdsaP256Sha256,
+  #[cfg(feature = "ecdsa-p384-sha384-signature")]
   EcdsaP384Sha384,
   #[cfg(feature = "ed25519-signature")]
   Ed25519,
@@ -23,8 +41,11 @@ pub enum AlgorithmName {
 impl AlgorithmName {
   pub fn as_str(&self) -> &'static str {
     match self {
+      #[cfg(feature = "hmac-sha256-signature")]
       AlgorithmName::HmacSha256 => "hmac-sha256",
+      #[cfg(feature = "ecdsa-p256-sha256-signature")]
       AlgorithmName::EcdsaP256Sha256 => "ecdsa-p256-sha256",
+      #[cfg(feature = "ecdsa-p384-sha384-signature")]
       AlgorithmName::EcdsaP384Sha384 => "ecdsa-p384-sha384",
       #[cfg(feature = "ed25519-signature")]
       AlgorithmName::Ed25519 => "ed25519",
@@ -47,8 +68,11 @@ impl core::str::FromStr for AlgorithmName {
 
   fn from_str(s: &str) -> Result<Self, Self::Err> {
     match s {
+      #[cfg(feature = "hmac-sha256-signature")]
       "hmac-sha256" => Ok(Self::HmacSha256),
+      #[cfg(feature = "ecdsa-p256-sha256-signature")]
       "ecdsa-p256-sha256" => Ok(Self::EcdsaP256Sha256),
+      #[cfg(feature = "ecdsa-p384-sha384-signature")]
       "ecdsa-p384-sha384" => Ok(Self::EcdsaP384Sha384),
       #[cfg(feature = "ed25519-signature")]
       "ed25519" => Ok(Self::Ed25519),
@@ -64,6 +88,7 @@ impl core::str::FromStr for AlgorithmName {
 /// SigningKey trait
 pub trait SigningKey {
   fn sign(&self, data: &[u8]) -> HttpSigResult<Vec<u8>>;
+  #[cfg(feature = "key-id")]
   fn key_id(&self) -> String;
   fn alg(&self) -> AlgorithmName;
 }
@@ -71,6 +96,7 @@ pub trait SigningKey {
 /// VerifyingKey trait
 pub trait VerifyingKey {
   fn verify(&self, data: &[u8], signature: &[u8]) -> HttpSigResult<()>;
+  #[cfg(feature = "key-id")]
   fn key_id(&self) -> String;
   fn alg(&self) -> AlgorithmName;
 }

--- a/httpsig/src/crypto/mod.rs
+++ b/httpsig/src/crypto/mod.rs
@@ -12,6 +12,7 @@ pub enum AlgorithmName {
   HmacSha256,
   EcdsaP256Sha256,
   EcdsaP384Sha384,
+  #[cfg(feature = "ed25519-signature")]
   Ed25519,
   #[cfg(feature = "rsa-signature")]
   RsaV1_5Sha256,
@@ -25,6 +26,7 @@ impl AlgorithmName {
       AlgorithmName::HmacSha256 => "hmac-sha256",
       AlgorithmName::EcdsaP256Sha256 => "ecdsa-p256-sha256",
       AlgorithmName::EcdsaP384Sha384 => "ecdsa-p384-sha384",
+      #[cfg(feature = "ed25519-signature")]
       AlgorithmName::Ed25519 => "ed25519",
       #[cfg(feature = "rsa-signature")]
       AlgorithmName::RsaV1_5Sha256 => "rsa-v1_5-sha256",
@@ -48,6 +50,7 @@ impl core::str::FromStr for AlgorithmName {
       "hmac-sha256" => Ok(Self::HmacSha256),
       "ecdsa-p256-sha256" => Ok(Self::EcdsaP256Sha256),
       "ecdsa-p384-sha384" => Ok(Self::EcdsaP384Sha384),
+      #[cfg(feature = "ed25519-signature")]
       "ed25519" => Ok(Self::Ed25519),
       #[cfg(feature = "rsa-signature")]
       "rsa-v1_5-sha256" => Ok(Self::RsaV1_5Sha256),

--- a/httpsig/src/crypto/symmetric.rs
+++ b/httpsig/src/crypto/symmetric.rs
@@ -66,7 +66,7 @@ impl super::VerifyingKey for SharedKey {
         mac.update(data);
         mac
           .verify_slice(expected_mac)
-          .map_err(|_| HttpSigError::InvalidSignature("Invalid MAC".to_string()))
+          .map_err(|_| HttpSigError::InvalidSignature("Invalid MAC".into()))
       }
     }
   }

--- a/httpsig/src/crypto/symmetric.rs
+++ b/httpsig/src/crypto/symmetric.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use base64::{engine::general_purpose, Engine as _};
 use hmac::{Hmac, Mac};
-use sha2::{Digest, Sha256};
 
 type HmacSha256 = Hmac<sha2::Sha256>;
 
@@ -25,6 +24,12 @@ impl SharedKey {
     let key = general_purpose::STANDARD.decode(key)?;
     match alg {
       AlgorithmName::HmacSha256 => Ok(SharedKey::HmacSha256(key)),
+      #[cfg(any(
+        feature = "ed25519-signature",
+        feature = "ecdsa-p256-sha256-signature",
+        feature = "ecdsa-p384-sha384-signature",
+        feature = "rsa-signature"
+      ))]
       _ => Err(HttpSigError::InvalidAlgorithmName(format!(
         "Unsupported algorithm for SharedKey: {}",
         alg
@@ -45,6 +50,7 @@ impl super::SigningKey for SharedKey {
       }
     }
   }
+  #[cfg(feature = "key-id")]
   /// Get the key id
   fn key_id(&self) -> String {
     use super::VerifyingKey;
@@ -71,11 +77,13 @@ impl super::VerifyingKey for SharedKey {
     }
   }
 
+  #[cfg(feature = "key-id")]
   /// Get the key id
   fn key_id(&self) -> String {
     match self {
       SharedKey::HmacSha256(key) => {
-        let mut hasher = <Sha256 as Digest>::new();
+        use sha2::Digest;
+        let mut hasher = <sha2::Sha256 as Digest>::new();
         hasher.update(key);
         let hash = hasher.finalize();
         general_purpose::STANDARD.encode(hash)

--- a/httpsig/src/error.rs
+++ b/httpsig/src/error.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use thiserror::Error;
 
 /// Result type for http signature
@@ -38,16 +40,16 @@ pub enum HttpSigError {
   InvalidComponentId(String),
   /// Invalid http message component
   #[error("Invalid http message component: {0}")]
-  InvalidComponent(String),
+  InvalidComponent(Cow<'static, str>),
 
   /* ----- Signature params errors ----- */
   /// Invalid signature params
   #[error("Invalid signature params: {0}")]
-  InvalidSignatureParams(String),
+  InvalidSignatureParams(&'static str),
 
   /// Error in building signature header
   #[error("Failed to build signature header: {0}")]
-  BuildSignatureHeaderError(String),
+  BuildSignatureHeaderError(&'static str),
 
   /// Error in building signature base
   #[error("Failed to build signature base: {0}")]

--- a/httpsig/src/error.rs
+++ b/httpsig/src/error.rs
@@ -14,16 +14,16 @@ pub enum HttpSigError {
   /* ----- Crypto errors ----- */
   /// Invalid private key for asymmetric algorithm
   #[error("Failed to parse private key: {0}")]
-  ParsePrivateKeyError(String),
+  ParsePrivateKeyError(Cow<'static, str>),
   /// Invalid public key for asymmetric algorithm
   #[error("Failed to parse public key: {0}")]
-  ParsePublicKeyError(String),
+  ParsePublicKeyError(Cow<'static, str>),
   /// Signature parse error
   #[error("Failed to parse signature: {0}")]
-  ParseSignatureError(String),
+  ParseSignatureError(Cow<'static, str>),
   /// Invalid Signature
   #[error("Invalid Signature: {0}")]
-  InvalidSignature(String),
+  InvalidSignature(Cow<'static, str>),
 
   /* ----- Component errors ----- */
   /// Failed to parse structured field value
@@ -53,11 +53,11 @@ pub enum HttpSigError {
 
   /// Error in building signature base
   #[error("Failed to build signature base: {0}")]
-  BuildSignatureBaseError(String),
+  BuildSignatureBaseError(&'static str),
 
   /// Expired signature params
   #[error("Expired signature params: {0}")]
-  ExpiredSignatureParams(String),
+  ExpiredSignatureParams(&'static str),
 
   /// Invalid algorithm name
   #[error("Invalid algorithm name: {0}")]
@@ -66,5 +66,5 @@ pub enum HttpSigError {
   /* ----- Other errors ----- */
   /// NotYetImplemented
   #[error("Not yet implemented: {0}")]
-  NotYetImplemented(String),
+  NotYetImplemented(&'static str),
 }

--- a/httpsig/src/lib.rs
+++ b/httpsig/src/lib.rs
@@ -32,7 +32,7 @@ pub mod prelude {
 }
 
 /* ----------------------------------------------------------------- */
-#[cfg(test)]
+#[cfg(all(test, feature = "ed25519-signature"))]
 mod tests {
   use super::prelude::*;
   use base64::{engine::general_purpose, Engine as _};

--- a/httpsig/src/lib.rs
+++ b/httpsig/src/lib.rs
@@ -21,8 +21,17 @@ pub mod prelude {
     };
   }
 
+  #[cfg(feature = "hmac-sha256-signature")]
+  pub use crate::crypto::SharedKey;
+  #[cfg(any(
+    feature = "ed25519-signature",
+    feature = "ecdsa-p256-sha256-signature",
+    feature = "ecdsa-p384-sha384-signature",
+    feature = "rsa-signature"
+  ))]
+  pub use crate::crypto::{PublicKey, SecretKey};
   pub use crate::{
-    crypto::{AlgorithmName, PublicKey, SecretKey, SharedKey, SigningKey, VerifyingKey},
+    crypto::{AlgorithmName, SigningKey, VerifyingKey},
     error::{HttpSigError, HttpSigResult},
     signature_base::{
       HttpSignature, HttpSignatureBase, HttpSignatureHeaders, HttpSignatureHeadersMap,
@@ -32,7 +41,7 @@ pub mod prelude {
 }
 
 /* ----------------------------------------------------------------- */
-#[cfg(all(test, feature = "ed25519-signature"))]
+#[cfg(test)]
 mod tests {
   use super::prelude::*;
   use base64::{engine::general_purpose, Engine as _};

--- a/httpsig/src/lib.rs
+++ b/httpsig/src/lib.rs
@@ -16,14 +16,17 @@ mod util;
 pub mod prelude {
   pub mod message_component {
     pub use crate::message_component::{
-      DerivedComponentName, HttpMessageComponent, HttpMessageComponentId, HttpMessageComponentName, HttpMessageComponentParam,
+      DerivedComponentName, HttpMessageComponent, HttpMessageComponentId, HttpMessageComponentName,
+      HttpMessageComponentParam,
     };
   }
 
   pub use crate::{
     crypto::{AlgorithmName, PublicKey, SecretKey, SharedKey, SigningKey, VerifyingKey},
     error::{HttpSigError, HttpSigResult},
-    signature_base::{HttpSignature, HttpSignatureBase, HttpSignatureHeaders, HttpSignatureHeadersMap},
+    signature_base::{
+      HttpSignature, HttpSignatureBase, HttpSignatureHeaders, HttpSignatureHeadersMap,
+    },
     signature_params::HttpSignatureParams,
   };
 }
@@ -51,7 +54,8 @@ MCowBQYDK2VwAyEAJrQLj5P/89iXES9+vFgrIy29clF9CC/oPPsw3c5D0bs=
 "content-type": application/json
 "content-length": 18
 "@signature-params": ("date" "@method" "@path" "@authority" "content-type" "content-length");created=1618884473;keyid="test-key-ed25519""##;
-  const EDDSA_SIGNATURE_VALUE: &str = "wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgwUPiu4A0w6vuQv5lIp5WPpBKRCw==";
+  const EDDSA_SIGNATURE_VALUE: &str =
+    "wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgwUPiu4A0w6vuQv5lIp5WPpBKRCw==";
   const _EDDSA_SIGNATURE_RESULT: &str = r##"Signature-Input: sig-b26=("date" "@method" "@path" "@authority" "content-type" "content-length");created=1618884473;keyid="test-key-ed25519"
 Signature: sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgwUPiu4A0w6vuQv5lIp5WPpBKRCw==:"##;
 
@@ -62,7 +66,9 @@ Signature: sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgw
     assert_eq!(pk.key_id(), sk.public_key().key_id());
 
     let data = EDDSA_SIGNATURE_BASE.as_bytes();
-    let binary_signature = general_purpose::STANDARD.decode(EDDSA_SIGNATURE_VALUE).unwrap();
+    let binary_signature = general_purpose::STANDARD
+      .decode(EDDSA_SIGNATURE_VALUE)
+      .unwrap();
     let verification_result = pk.verify(data, &binary_signature);
     assert!(verification_result.is_ok());
 
@@ -89,7 +95,9 @@ Signature: sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgw
     let sk = SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
 
     let data = HMACSHA256_SIGNATURE_BASE.as_bytes();
-    let binary_signature = general_purpose::STANDARD.decode(HMACSHA256_SIGNATURE_VALUE).unwrap();
+    let binary_signature = general_purpose::STANDARD
+      .decode(HMACSHA256_SIGNATURE_VALUE)
+      .unwrap();
     let verification_result = sk.verify(data, &binary_signature);
     assert!(verification_result.is_ok());
 
@@ -111,8 +119,7 @@ Signature: sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgw
     r##""content-type": application/json"##,
     r##""content-length": 18"##,
   ];
-  const SIGNATURE_PARAMS: &str =
-    r##"("date" "@method" "@path" "@authority" "content-type" "content-length");created=1618884473;keyid="test-key-ed25519""##;
+  const SIGNATURE_PARAMS: &str = r##"("date" "@method" "@path" "@authority" "content-type" "content-length");created=1618884473;keyid="test-key-ed25519""##;
 
   #[test]
   fn test_with_directly_using_crypto_api() {
@@ -122,7 +129,7 @@ Signature: sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgw
       .map(|&line| message_component::HttpMessageComponent::try_from(line).unwrap())
       .collect::<Vec<_>>();
 
-    let signature_base = HttpSignatureBase::try_new(&component_lines, &signature_params).unwrap();
+    let signature_base = HttpSignatureBase::try_new(component_lines, &signature_params).unwrap();
     let sk = SecretKey::from_pem(&AlgorithmName::Ed25519, EDDSA_SECRET_KEY).unwrap();
     let pk = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
 
@@ -140,22 +147,36 @@ Signature: sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgw
 
     // sender
     let signature_params = HttpSignatureParams::try_from(SIGNATURE_PARAMS).unwrap();
-    let signature_base = HttpSignatureBase::try_new(&component_lines, &signature_params).unwrap();
+    let signature_base =
+      HttpSignatureBase::try_new(component_lines.clone(), &signature_params).unwrap();
     let sk = SecretKey::from_pem(&AlgorithmName::Ed25519, EDDSA_SECRET_KEY).unwrap();
-    let signature_headers = signature_base.build_signature_headers(&sk, Some("sig-b26")).unwrap();
+    let signature_headers = signature_base
+      .build_signature_headers(&sk, Some("sig-b26"))
+      .unwrap();
     let signature_params_header_string = signature_headers.signature_input_header_value();
     let signature_header_string = signature_headers.signature_header_value();
 
-    assert_eq!(signature_params_header_string, format!("sig-b26={}", SIGNATURE_PARAMS));
-    assert!(signature_header_string.starts_with("sig-b26=:") && signature_header_string.ends_with(':'));
+    assert_eq!(
+      signature_params_header_string,
+      format!("sig-b26={}", SIGNATURE_PARAMS)
+    );
+    assert!(
+      signature_header_string.starts_with("sig-b26=:") && signature_header_string.ends_with(':')
+    );
 
     // receiver
-    let header_map = HttpSignatureHeaders::try_parse(&signature_header_string, &signature_params_header_string).unwrap();
+    let header_map =
+      HttpSignatureHeaders::try_parse(&signature_header_string, &signature_params_header_string)
+        .unwrap();
     let received_signature_headers = header_map.get("sig-b26").unwrap();
-    let received_signature_base =
-      HttpSignatureBase::try_new(&component_lines, received_signature_headers.signature_params()).unwrap();
+    let received_signature_base = HttpSignatureBase::try_new(
+      component_lines,
+      received_signature_headers.signature_params(),
+    )
+    .unwrap();
     let pk = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
-    let verification_result = received_signature_base.verify_signature_headers(&pk, received_signature_headers);
+    let verification_result =
+      received_signature_base.verify_signature_headers(&pk, received_signature_headers);
     assert!(verification_result.is_ok());
   }
 }

--- a/httpsig/src/message_component/component.rs
+++ b/httpsig/src/message_component/component.rs
@@ -25,9 +25,9 @@ impl TryFrom<&str> for HttpMessageComponent {
   /// We suppose that the value was correctly serialized as a line of signature base.
   fn try_from(val: &str) -> Result<Self, Self::Error> {
     let Some((id, value)) = val.split_once(':') else {
-      return Err(HttpSigError::InvalidComponent(format!(
-        "Invalid http message component: {val}"
-      )));
+      return Err(HttpSigError::InvalidComponent(
+        format!("Invalid http message component: {val}").into(),
+      ));
     };
     let id = id.trim();
 
@@ -40,16 +40,18 @@ impl TryFrom<&str> for HttpMessageComponent {
 
     Ok(Self {
       id: HttpMessageComponentId::try_from(id)?,
-      value: HttpMessageComponentValue::from(value.trim()),
+      value: HttpMessageComponentValue::from(value.trim().to_owned()),
     })
   }
 }
 
-impl TryFrom<(&HttpMessageComponentId, &[String])> for HttpMessageComponent {
+impl TryFrom<(&HttpMessageComponentId, Vec<String>)> for HttpMessageComponent {
   type Error = HttpSigError;
 
   /// Build http message component from given id and its associated field values
-  fn try_from((id, field_values): (&HttpMessageComponentId, &[String])) -> Result<Self, Self::Error> {
+  fn try_from(
+    (id, field_values): (&HttpMessageComponentId, Vec<String>),
+  ) -> Result<Self, Self::Error> {
     match &id.name {
       HttpMessageComponentName::HttpField(_) => build_http_field_component(id, field_values),
       HttpMessageComponentName::Derived(_) => build_derived_component(id, field_values),
@@ -69,39 +71,49 @@ impl std::fmt::Display for HttpMessageComponent {
 /// Build derived component from given id and its associated field values
 pub(super) fn build_derived_component(
   id: &HttpMessageComponentId,
-  field_values: &[String],
+  field_values: Vec<String>,
 ) -> HttpSigResult<HttpMessageComponent> {
   let HttpMessageComponentName::Derived(derived_id) = &id.name else {
     return Err(HttpSigError::InvalidComponent(
-      "invalid http message component name as derived component".to_string(),
+      "invalid http message component name as derived component".into(),
     ));
   };
   if field_values.is_empty() {
     return Err(HttpSigError::InvalidComponent(
-      "derived component requires field values".to_string(),
+      "derived component requires field values".into(),
     ));
   }
   // ensure only `req` and `name` are allowed for derived component parameters
-  if !id
-    .params
-    .0
-    .iter()
-    .all(|p| matches!(p, HttpMessageComponentParam::Req | HttpMessageComponentParam::Name(_)))
-  {
+  if !id.params.0.iter().all(|p| {
+    matches!(
+      p,
+      HttpMessageComponentParam::Req | HttpMessageComponentParam::Name(_)
+    )
+  }) {
     return Err(HttpSigError::InvalidComponent(
-      "invalid parameter for derived component".to_string(),
+      "invalid parameter for derived component".into(),
     ));
   }
 
+  fn first(field_values: Vec<String>) -> String {
+    field_values.into_iter().next().expect("not empty")
+  }
+
   let value = match derived_id {
-    DerivedComponentName::Method => HttpMessageComponentValue::from(field_values[0].to_ascii_uppercase().as_ref()),
-    DerivedComponentName::TargetUri => HttpMessageComponentValue::from(field_values[0].to_string().as_ref()),
-    DerivedComponentName::Authority => HttpMessageComponentValue::from(field_values[0].to_ascii_lowercase().as_ref()),
-    DerivedComponentName::Scheme => HttpMessageComponentValue::from(field_values[0].to_ascii_lowercase().as_ref()),
-    DerivedComponentName::RequestTarget => HttpMessageComponentValue::from(field_values[0].to_string().as_ref()),
-    DerivedComponentName::Path => HttpMessageComponentValue::from(field_values[0].to_string().as_ref()),
-    DerivedComponentName::Query => HttpMessageComponentValue::from(field_values[0].to_string().as_ref()),
-    DerivedComponentName::Status => HttpMessageComponentValue::from(field_values[0].to_string().as_ref()),
+    DerivedComponentName::Method => {
+      HttpMessageComponentValue::from(field_values[0].to_ascii_uppercase())
+    }
+    DerivedComponentName::TargetUri => HttpMessageComponentValue::from(first(field_values)),
+    DerivedComponentName::Authority => {
+      HttpMessageComponentValue::from(field_values[0].to_ascii_lowercase())
+    }
+    DerivedComponentName::Scheme => {
+      HttpMessageComponentValue::from(field_values[0].to_ascii_lowercase())
+    }
+    DerivedComponentName::RequestTarget => HttpMessageComponentValue::from(first(field_values)),
+    DerivedComponentName::Path => HttpMessageComponentValue::from(first(field_values)),
+    DerivedComponentName::Query => HttpMessageComponentValue::from(first(field_values)),
+    DerivedComponentName::Status => HttpMessageComponentValue::from(first(field_values)),
     DerivedComponentName::QueryParam => {
       let name = id.params.0.iter().find_map(|p| match p {
         HttpMessageComponentParam::Name(name) => Some(name),
@@ -109,7 +121,7 @@ pub(super) fn build_derived_component(
       });
       if name.is_none() {
         return Err(HttpSigError::InvalidComponent(
-          "query-param derived component requires name parameter".to_string(),
+          "query-param derived component requires name parameter".into(),
         ));
       };
       let name = name.unwrap();
@@ -120,21 +132,24 @@ pub(super) fn build_derived_component(
         .filter(|(k, _)| *k == name.as_str())
         .map(|(_, v)| v)
         .collect::<Vec<_>>();
-      HttpMessageComponentValue::from(kvs.join(", ").as_ref())
+      HttpMessageComponentValue::from(kvs.join(", "))
     }
     DerivedComponentName::SignatureParams => {
-      let value = field_values[0].to_string();
+      let value = first(field_values);
       let opt_pair = value.trim().split_once('=');
       if opt_pair.is_none() {
         return Err(HttpSigError::InvalidComponent(
-          "invalid signature-params derived component".to_string(),
+          "invalid signature-params derived component".into(),
         ));
       }
       let (key, value) = opt_pair.unwrap();
-      HttpMessageComponentValue::from((key, value))
+      HttpMessageComponentValue::from((key.to_owned(), value.to_owned()))
     }
   };
-  let component = HttpMessageComponent { id: id.clone(), value };
+  let component = HttpMessageComponent {
+    id: id.clone(),
+    value,
+  };
   Ok(component)
 }
 
@@ -143,9 +158,8 @@ pub(super) fn build_derived_component(
 /// NOTE: field_value must be ones of request for `req` param
 pub(super) fn build_http_field_component(
   id: &HttpMessageComponentId,
-  field_values: &[String],
+  mut field_values: Vec<String>,
 ) -> HttpSigResult<HttpMessageComponent> {
-  let mut field_values = field_values.to_vec();
   let params = &id.params;
 
   for p in params.0.iter() {
@@ -154,15 +168,21 @@ pub(super) fn build_http_field_component(
         handle_params_sf(&mut field_values)?;
       }
       HttpMessageComponentParam::Key(key) => {
-        field_values = handle_params_key_into(&field_values, key)?;
+        field_values = handle_params_key_into(field_values.as_ref(), key)?;
       }
       HttpMessageComponentParam::Bs => {
-        return Err(HttpSigError::NotYetImplemented("`bs` is not supported yet".to_string()));
+        return Err(HttpSigError::NotYetImplemented(
+          "`bs` is not supported yet".to_string(),
+        ));
       }
       HttpMessageComponentParam::Req => {
         debug!("`req` is given for http field component");
       }
-      HttpMessageComponentParam::Tr => return Err(HttpSigError::NotYetImplemented("`tr` is not supported yet".to_string())),
+      HttpMessageComponentParam::Tr => {
+        return Err(HttpSigError::NotYetImplemented(
+          "`tr` is not supported yet".to_string(),
+        ))
+      }
       HttpMessageComponentParam::Name(_) => {
         return Err(HttpSigError::NotYetImplemented(
           "`name` is only for derived component query-params".to_string(),
@@ -177,7 +197,7 @@ pub(super) fn build_http_field_component(
 
   let component = HttpMessageComponent {
     id: id.clone(),
-    value: HttpMessageComponentValue::from(field_values_str.as_ref()),
+    value: HttpMessageComponentValue::from(field_values_str),
   };
   Ok(component)
 }
@@ -192,13 +212,29 @@ mod tests {
   fn test_from_serialized_string_derived() {
     let tuples = vec![
       ("\"@method\"", "POST", DerivedComponentName::Method),
-      ("\"@target-uri\"", "https://example.com/", DerivedComponentName::TargetUri),
-      ("\"@authority\"", "example.com", DerivedComponentName::Authority),
+      (
+        "\"@target-uri\"",
+        "https://example.com/",
+        DerivedComponentName::TargetUri,
+      ),
+      (
+        "\"@authority\"",
+        "example.com",
+        DerivedComponentName::Authority,
+      ),
       ("\"@scheme\"", "https", DerivedComponentName::Scheme),
-      ("\"@request-target\"", "/path?query", DerivedComponentName::RequestTarget),
+      (
+        "\"@request-target\"",
+        "/path?query",
+        DerivedComponentName::RequestTarget,
+      ),
       ("\"@path\"", "/path", DerivedComponentName::Path),
       ("\"@query\"", "query", DerivedComponentName::Query),
-      ("\"@query-param\";name=\"key\"", "\"value\"", DerivedComponentName::QueryParam),
+      (
+        "\"@query-param\";name=\"key\"",
+        "\"value\"",
+        DerivedComponentName::QueryParam,
+      ),
       ("\"@status\"", "200", DerivedComponentName::Status),
     ];
     for (id, value, name) in tuples {
@@ -209,7 +245,7 @@ mod tests {
       } else {
         assert!(!comp.id.params.0.is_empty());
       }
-      assert_eq!(comp.value.as_field_value(), value);
+      assert_eq!(comp.value.to_field_value(), value);
       assert_eq!(comp.value.key(), None);
       assert_eq!(comp.to_string(), format!("{}: {}", id, value));
     }
@@ -217,14 +253,22 @@ mod tests {
 
   #[test]
   fn test_from_serialized_string_derived_query_params() {
-    let (id, value, name) = ("\"@query-param\";name=\"key\"", "\"value\"", DerivedComponentName::QueryParam);
+    let (id, value, name) = (
+      "\"@query-param\";name=\"key\"",
+      "\"value\"",
+      DerivedComponentName::QueryParam,
+    );
     let comp = HttpMessageComponent::try_from(format!("{}: {}", id, value).as_ref()).unwrap();
     assert_eq!(comp.id.name, HttpMessageComponentName::Derived(name));
     assert_eq!(
-      comp.id.params.0.get(&HttpMessageComponentParam::Name("key".to_string())),
+      comp
+        .id
+        .params
+        .0
+        .get(&HttpMessageComponentParam::Name("key".to_string())),
       Some(&HttpMessageComponentParam::Name("key".to_string()))
     );
-    assert_eq!(comp.value.as_field_value(), value);
+    assert_eq!(comp.value.to_field_value(), value);
     assert_eq!(comp.value.key(), None);
     assert_eq!(comp.to_string(), format!("{}: {}", id, value));
   }
@@ -233,19 +277,26 @@ mod tests {
   fn test_from_serialized_string_http_field() {
     let tuples = vec![
       ("\"example-header\"", "example-value", "example-header"),
-      ("\"example-header\";bs;tr", "example-value", "example-header"),
+      (
+        "\"example-header\";bs;tr",
+        "example-value",
+        "example-header",
+      ),
       ("\"example-header\";bs", "example-value", "example-header"),
       ("\"x-empty-header\"", "", "x-empty-header"),
     ];
     for (id, value, inner_name) in tuples {
       let comp = HttpMessageComponent::try_from(format!("{}: {}", id, value).as_ref()).unwrap();
-      assert_eq!(comp.id.name, HttpMessageComponentName::HttpField(inner_name.to_string()));
+      assert_eq!(
+        comp.id.name,
+        HttpMessageComponentName::HttpField(inner_name.to_string())
+      );
       if !id.contains(';') {
         assert_eq!(comp.id.params.0, IndexSet::default());
       } else {
         assert!(!comp.id.params.0.is_empty());
       }
-      assert_eq!(comp.value.as_field_value(), value);
+      assert_eq!(comp.value.to_field_value(), value);
       assert_eq!(comp.to_string(), format!("{}: {}", id, value));
     }
   }
@@ -267,7 +318,8 @@ mod tests {
 
   #[test]
   fn test_from_serialized_string_http_field_params_key() {
-    let comp = HttpMessageComponent::try_from("\"example-header\";key=\"hoge\": example-value").unwrap();
+    let comp =
+      HttpMessageComponent::try_from("\"example-header\";key=\"hoge\": example-value").unwrap();
     assert_eq!(
       comp.id.name,
       HttpMessageComponentName::HttpField("example-header".to_string())
@@ -299,20 +351,26 @@ mod tests {
   fn test_build_http_field_component() {
     let id = HttpMessageComponentId::try_from("content-type").unwrap();
     let field_values = vec!["application/json".to_owned()];
-    let component = build_http_field_component(&id, &field_values).unwrap();
+    let component = build_http_field_component(&id, field_values).unwrap();
     assert_eq!(component.id, id);
-    assert_eq!(component.value, HttpMessageComponentValue::from("application/json"));
+    assert_eq!(
+      component.value,
+      HttpMessageComponentValue::from("application/json".to_owned())
+    );
     assert_eq!(component.to_string(), "\"content-type\": application/json");
   }
   #[test]
   fn test_build_http_field_component_multiple_values() {
     let id = HttpMessageComponentId::try_from("\"content-type\"").unwrap();
-    let field_values = vec!["application/json".to_owned(), "application/json-patch+json".to_owned()];
-    let component = build_http_field_component(&id, &field_values).unwrap();
+    let field_values = vec![
+      "application/json".to_owned(),
+      "application/json-patch+json".to_owned(),
+    ];
+    let component = build_http_field_component(&id, field_values).unwrap();
     assert_eq!(component.id, id);
     assert_eq!(
       component.value,
-      HttpMessageComponentValue::from("application/json, application/json-patch+json")
+      HttpMessageComponentValue::from("application/json, application/json-patch+json".to_owned())
     );
     assert_eq!(
       component.to_string(),
@@ -326,11 +384,13 @@ mod tests {
       "application/json; patched=true".to_owned(),
       "application/json-patch+json;patched".to_owned(),
     ];
-    let component = build_http_field_component(&id, &field_values).unwrap();
+    let component = build_http_field_component(&id, field_values).unwrap();
     assert_eq!(component.id, id);
     assert_eq!(
       component.value,
-      HttpMessageComponentValue::from("application/json;patched=true, application/json-patch+json;patched")
+      HttpMessageComponentValue::from(
+        "application/json;patched=true, application/json-patch+json;patched".to_owned()
+      )
     );
     assert_eq!(
       component.to_string(),
@@ -341,10 +401,16 @@ mod tests {
   fn test_build_http_field_component_key() {
     let id = HttpMessageComponentId::try_from("\"example-header\";key=\"patched\"").unwrap();
     let field_values = vec!["patched=12345678".to_owned()];
-    let component = build_http_field_component(&id, &field_values).unwrap();
+    let component = build_http_field_component(&id, field_values).unwrap();
     assert_eq!(component.id, id);
-    assert_eq!(component.value, HttpMessageComponentValue::from("12345678"));
-    assert_eq!(component.to_string(), "\"example-header\";key=\"patched\": 12345678");
+    assert_eq!(
+      component.value,
+      HttpMessageComponentValue::from("12345678".to_string())
+    );
+    assert_eq!(
+      component.to_string(),
+      "\"example-header\";key=\"patched\": 12345678"
+    );
   }
   #[test]
   fn test_build_http_field_component_key_multiple_values() {
@@ -354,9 +420,12 @@ mod tests {
       "patched=87654321".to_owned(),
       "not-patched=12345678".to_owned(),
     ];
-    let component = build_http_field_component(&id, &field_values).unwrap();
+    let component = build_http_field_component(&id, field_values).unwrap();
     assert_eq!(component.id, id);
-    assert_eq!(component.value, HttpMessageComponentValue::from("12345678, 87654321"));
+    assert_eq!(
+      component.value,
+      HttpMessageComponentValue::from("12345678, 87654321".to_string())
+    );
     assert_eq!(
       component.to_string(),
       "\"example-header\";key=\"patched\": 12345678, 87654321"
@@ -367,28 +436,40 @@ mod tests {
   fn test_build_derived_component() {
     let id = HttpMessageComponentId::try_from("@method").unwrap();
     let field_values = vec!["GET".to_owned()];
-    let component = build_derived_component(&id, &field_values).unwrap();
+    let component = build_derived_component(&id, field_values).unwrap();
     assert_eq!(component.id, id);
-    assert_eq!(component.value, HttpMessageComponentValue::from("GET"));
+    assert_eq!(
+      component.value,
+      HttpMessageComponentValue::from("GET".to_owned())
+    );
     assert_eq!(component.to_string(), "\"@method\": GET");
 
     let id = HttpMessageComponentId::try_from("@target-uri").unwrap();
     let field_values = vec!["https://example.com/foo".to_owned()];
-    let component = build_derived_component(&id, &field_values).unwrap();
+    let component = build_derived_component(&id, field_values).unwrap();
     assert_eq!(component.id, id);
-    assert_eq!(component.value, HttpMessageComponentValue::from("https://example.com/foo"));
-    assert_eq!(component.to_string(), "\"@target-uri\": https://example.com/foo");
+    assert_eq!(
+      component.value,
+      HttpMessageComponentValue::from("https://example.com/foo".to_owned())
+    );
+    assert_eq!(
+      component.to_string(),
+      "\"@target-uri\": https://example.com/foo"
+    );
   }
   #[test]
   fn test_build_http_field_component_query_param() {
     let id = HttpMessageComponentId::try_from("\"@query-param\";name=\"var\"").unwrap();
     let query_param = "var=this%20is%20a%20big%0Amultiline%20value&bar=with+plus+whitespace&fa%C3%A7ade%22%3A%20=something&ok";
-    let field_values = query_param.split('&').map(|v| v.to_owned()).collect::<Vec<_>>();
-    let component = build_derived_component(&id, &field_values).unwrap();
+    let field_values = query_param
+      .split('&')
+      .map(|v| v.to_owned())
+      .collect::<Vec<_>>();
+    let component = build_derived_component(&id, field_values).unwrap();
     assert_eq!(component.id, id);
     assert_eq!(
       component.value,
-      HttpMessageComponentValue::from("this%20is%20a%20big%0Amultiline%20value")
+      HttpMessageComponentValue::from("this%20is%20a%20big%0Amultiline%20value".to_owned())
     );
     assert_eq!(
       component.to_string(),

--- a/httpsig/src/message_component/component.rs
+++ b/httpsig/src/message_component/component.rs
@@ -171,21 +171,17 @@ pub(super) fn build_http_field_component(
         field_values = handle_params_key_into(field_values.as_ref(), key)?;
       }
       HttpMessageComponentParam::Bs => {
-        return Err(HttpSigError::NotYetImplemented(
-          "`bs` is not supported yet".to_string(),
-        ));
+        return Err(HttpSigError::NotYetImplemented("`bs` is not supported yet"));
       }
       HttpMessageComponentParam::Req => {
         debug!("`req` is given for http field component");
       }
       HttpMessageComponentParam::Tr => {
-        return Err(HttpSigError::NotYetImplemented(
-          "`tr` is not supported yet".to_string(),
-        ))
+        return Err(HttpSigError::NotYetImplemented("`tr` is not supported yet"))
       }
       HttpMessageComponentParam::Name(_) => {
         return Err(HttpSigError::NotYetImplemented(
-          "`name` is only for derived component query-params".to_string(),
+          "`name` is only for derived component query-params",
         ));
       }
     }

--- a/httpsig/src/message_component/component_param.rs
+++ b/httpsig/src/message_component/component_param.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::error::{HttpSigError, HttpSigResult};
 use sfv::{FieldType, Parser};
 
@@ -24,15 +26,17 @@ pub enum HttpMessageComponentParam {
   Name(String),
 }
 
-impl From<HttpMessageComponentParam> for String {
-  fn from(val: HttpMessageComponentParam) -> Self {
+impl From<&HttpMessageComponentParam> for Cow<'static, str> {
+  fn from(val: &HttpMessageComponentParam) -> Self {
     match val {
-      HttpMessageComponentParam::Sf => "sf".to_string(),
-      HttpMessageComponentParam::Key(val) => format!("key=\"{val}\""),
-      HttpMessageComponentParam::Bs => "bs".to_string(),
-      HttpMessageComponentParam::Tr => "tr".to_string(),
-      HttpMessageComponentParam::Req => "req".to_string(),
-      HttpMessageComponentParam::Name(v) => format!("name=\"{v}\""),
+      HttpMessageComponentParam::Sf => "sf".into(),
+      // join allocates String with exact required capacity without reallocations
+      HttpMessageComponentParam::Key(val) => ["key=\"", val.as_str(), "\""].join("").into(),
+      HttpMessageComponentParam::Bs => "bs".into(),
+      HttpMessageComponentParam::Tr => "tr".into(),
+      HttpMessageComponentParam::Req => "req".into(),
+      // join allocates String with exact required capacity without reallocations
+      HttpMessageComponentParam::Name(v) => ["name=\"", v.as_str(), "\""].join("").into(),
     }
   }
 }
@@ -70,7 +74,11 @@ pub struct HttpMessageComponentParams(pub IndexSet<HttpMessageComponentParam>);
 
 impl std::hash::Hash for HttpMessageComponentParams {
   fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    let mut params = self.0.iter().map(|v| v.clone().into()).collect::<Vec<String>>();
+    let mut params = self
+      .0
+      .iter()
+      .map(Cow::from)
+      .collect::<Vec<Cow<'static, str>>>();
     params.sort();
     params.hash(state);
   }
@@ -92,7 +100,12 @@ impl std::fmt::Display for HttpMessageComponentParams {
       write!(
         f,
         ";{}",
-        self.0.iter().map(|v| v.clone().into()).collect::<Vec<String>>().join(";")
+        self
+          .0
+          .iter()
+          .map(Cow::from)
+          .collect::<Vec<Cow<'static, str>>>()
+          .join(";")
       )
     } else {
       Ok(())
@@ -107,15 +120,21 @@ pub(super) fn handle_params_sf(field_values: &mut [String]) -> HttpSigResult<()>
     .iter()
     .map(|v| {
       if let Ok(list) = Parser::new(v).parse::<sfv::List>() {
-        list.serialize().ok_or("Failed to serialize structured field value for sf")
+        list
+          .serialize()
+          .ok_or("Failed to serialize structured field value for sf")
       } else if let Ok(dict) = Parser::new(v).parse::<sfv::Dictionary>() {
-        dict.serialize().ok_or("Failed to serialize structured field value for sf")
+        dict
+          .serialize()
+          .ok_or("Failed to serialize structured field value for sf")
       } else {
         Err("invalid structured field value for sf")
       }
     })
     .collect::<Result<Vec<_>, _>>()
-    .map_err(|e| HttpSigError::InvalidComponentParam(format!("Failed to parse structured field value: {e}")))?;
+    .map_err(|e| {
+      HttpSigError::InvalidComponentParam(format!("Failed to parse structured field value: {e}"))
+    })?;
 
   field_values.iter_mut().zip(parsed_list).for_each(|(v, p)| {
     *v = p;
@@ -126,13 +145,18 @@ pub(super) fn handle_params_sf(field_values: &mut [String]) -> HttpSigResult<()>
 
 /* ---------------------------------------------------------------- */
 /// Handle `key` parameter, returns new field values
-pub(super) fn handle_params_key_into(field_values: &[String], key: &str) -> HttpSigResult<Vec<String>> {
+pub(super) fn handle_params_key_into(
+  field_values: &[String],
+  key: &str,
+) -> HttpSigResult<Vec<String>> {
   let dicts = field_values
     .iter()
     .map(|v| Parser::new(v.as_str()).parse() as Result<sfv::Dictionary, _>)
     // Parser::parse_dictionary(v.as_bytes()))
     .collect::<Result<Vec<_>, _>>()
-    .map_err(|e| HttpSigError::InvalidComponentParam(format!("Failed to parse structured field value: {e}")))?;
+    .map_err(|e| {
+      HttpSigError::InvalidComponentParam(format!("Failed to parse structured field value: {e}"))
+    })?;
 
   let found_entries = dicts
     .into_iter()
@@ -144,7 +168,9 @@ pub(super) fn handle_params_key_into(field_values: &[String], key: &str) -> Http
       })
     })
     .collect::<Option<Vec<_>>>()
-    .ok_or_else(|| HttpSigError::InvalidComponentParam(format!("Failed to serialize structured field value")))?;
+    .ok_or_else(|| {
+      HttpSigError::InvalidComponentParam(format!("Failed to serialize structured field value"))
+    })?;
 
   Ok(found_entries)
 }
@@ -165,11 +191,16 @@ mod tests {
     // Parsing structured field value of List type.
     let list_header_input = "  1; a=tok, (\"foo\"   \"bar\" );baz, (  )";
     let list = Parser::new(list_header_input).parse::<sfv::List>().unwrap();
-    assert_eq!(list.serialize().unwrap(), "1;a=tok, (\"foo\" \"bar\");baz, ()");
+    assert_eq!(
+      list.serialize().unwrap(),
+      "1;a=tok, (\"foo\" \"bar\");baz, ()"
+    );
 
     // Parsing structured field value of Dictionary type.
     let dict_header_input = "a=?0, b, c; foo=bar, rating=1.5, fruits=(apple pear), d";
-    let dict = Parser::new(dict_header_input).parse::<sfv::Dictionary>().unwrap();
+    let dict = Parser::new(dict_header_input)
+      .parse::<sfv::Dictionary>()
+      .unwrap();
     assert_eq!(
       dict.serialize().unwrap(),
       "a=?0, b, c;foo=bar, rating=1.5, fruits=(apple pear), d"

--- a/httpsig/src/message_component/component_value.rs
+++ b/httpsig/src/message_component/component_value.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 /* ---------------------------------------------------------------- */
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Http message component value
@@ -6,18 +8,18 @@ pub struct HttpMessageComponentValue {
   inner: HttpMessageComponentValueInner,
 }
 
-impl From<&str> for HttpMessageComponentValue {
-  fn from(val: &str) -> Self {
+impl From<String> for HttpMessageComponentValue {
+  fn from(val: String) -> Self {
     Self {
-      inner: HttpMessageComponentValueInner::String(val.to_string()),
+      inner: HttpMessageComponentValueInner::String(val),
     }
   }
 }
 
-impl From<(&str, &str)> for HttpMessageComponentValue {
-  fn from((key, val): (&str, &str)) -> Self {
+impl From<(String, String)> for HttpMessageComponentValue {
+  fn from((key, val): (String, String)) -> Self {
     Self {
-      inner: HttpMessageComponentValueInner::KeyValue((key.to_string(), val.to_string())),
+      inner: HttpMessageComponentValueInner::KeyValue((key, val)),
     }
   }
 }
@@ -55,10 +57,10 @@ impl HttpMessageComponentValue {
     }
   }
   /// Get key value connected with `=`, or just value
-  pub fn as_field_value(&self) -> String {
+  pub fn to_field_value(&self) -> Cow<'_, str> {
     match &self.inner {
-      HttpMessageComponentValueInner::String(val) => val.to_owned(),
-      HttpMessageComponentValueInner::KeyValue((key, val)) => format!("{}={}", key, val),
+      HttpMessageComponentValueInner::String(val) => val.into(),
+      HttpMessageComponentValueInner::KeyValue((key, val)) => format!("{}={}", key, val).into(),
     }
   }
   /// Get value only

--- a/httpsig/src/signature_base.rs
+++ b/httpsig/src/signature_base.rs
@@ -161,7 +161,7 @@ impl HttpSignatureBase {
     // check if the order of component lines is the same as the order of covered message component ids
     if component_lines.len() != signature_params.covered_components.len() {
       return Err(HttpSigError::BuildSignatureBaseError(
-        "The number of component lines is not the same as the number of covered message component ids".to_string(),
+        "The number of component lines is not the same as the number of covered message component ids",
       ));
     }
 
@@ -171,7 +171,7 @@ impl HttpSignatureBase {
       .all(|(component_line, covered_component_id)| component_line.id == *covered_component_id);
     if !assertion {
       return Err(HttpSigError::BuildSignatureBaseError(
-        "The order of component lines is not the same as the order of covered message component ids".to_string(),
+        "The order of component lines is not the same as the order of covered message component ids",
       ));
     }
 
@@ -216,7 +216,7 @@ impl HttpSignatureBase {
   ) -> HttpSigResult<()> {
     if signature_headers.signature_params().is_expired() {
       return Err(HttpSigError::ExpiredSignatureParams(
-        "Signature params is expired".to_string(),
+        "Signature params is expired",
       ));
     }
     let signature_bytes = signature_headers.signature.0.as_slice();

--- a/httpsig/src/signature_base.rs
+++ b/httpsig/src/signature_base.rs
@@ -29,11 +29,14 @@ pub struct HttpSignatureHeaders {
 
 impl HttpSignatureHeaders {
   /// Generates (possibly multiple) HttpSignatureHeaders from signature and signature-input header values
-  pub fn try_parse(signature_header: &str, signature_input_header: &str) -> HttpSigResult<HttpSignatureHeadersMap> {
+  pub fn try_parse(
+    signature_header: &str,
+    signature_input_header: &str,
+  ) -> HttpSigResult<HttpSignatureHeadersMap> {
     let signature_input: sfv::Dictionary = Parser::new(signature_input_header)
       .parse()
       .map_err(|e| HttpSigError::ParseSFVError(e.to_string()))?;
-    let signature: sfv::Dictionary = Parser::new(signature_header)
+    let mut signature: sfv::Dictionary = Parser::new(signature_header)
       .parse()
       .map_err(|e| HttpSigError::ParseSFVError(e.to_string()))?;
     // let signature_input =
@@ -43,13 +46,13 @@ impl HttpSignatureHeaders {
 
     if signature.len() != signature_input.len() {
       return Err(HttpSigError::BuildSignatureHeaderError(
-        "The number of signature and signature-input headers are not the same".to_string(),
+        "The number of signature and signature-input headers are not the same",
       ));
     }
 
     if !signature.keys().all(|k| signature_input.contains_key(k)) {
       return Err(HttpSigError::BuildSignatureHeaderError(
-        "The signature and signature-input headers are not the same".to_string(),
+        "The signature and signature-input headers are not the same",
       ));
     }
     if !signature.values().all(|v| {
@@ -62,12 +65,15 @@ impl HttpSignatureHeaders {
       )
     }) {
       return Err(HttpSigError::BuildSignatureHeaderError(
-        "The signature header is not a dictionary".to_string(),
+        "The signature header is not a dictionary",
       ));
     }
-    if !signature_input.values().all(|v| matches!(v, ListEntry::InnerList(_))) {
+    if !signature_input
+      .values()
+      .all(|v| matches!(v, ListEntry::InnerList(_)))
+    {
       return Err(HttpSigError::BuildSignatureHeaderError(
-        "The signature-input header is not a dictionary".to_string(),
+        "The signature-input header is not a dictionary",
       ));
     }
 
@@ -77,14 +83,14 @@ impl HttpSignatureHeaders {
         let signature_name = k.to_string();
         let signature_params = HttpSignatureParams::try_from(v)?;
 
-        let signature_bytes = match signature.get(k) {
+        let signature_bytes = match signature.swap_remove(k) {
           Some(ListEntry::Item(Item {
             bare_item: BareItem::ByteSequence(v),
             ..
           })) => v,
           _ => unreachable!(),
         };
-        let signature = HttpSignature(signature_bytes.to_vec());
+        let signature = HttpSignature(signature_bytes);
 
         Ok((
           signature_name.clone(),
@@ -148,7 +154,10 @@ impl HttpSignatureBase {
   /// This should not be exposed to user and not used directly.
   /// Use wrapper functions generating SignatureBase from base HTTP request and Signer itself instead when newly generating signature
   /// When verifying signature, use wrapper functions generating SignatureBase from HTTP request containing signature params itself instead.
-  pub fn try_new(component_lines: &[HttpMessageComponent], signature_params: &HttpSignatureParams) -> HttpSigResult<Self> {
+  pub fn try_new(
+    component_lines: Vec<HttpMessageComponent>,
+    signature_params: &HttpSignatureParams,
+  ) -> HttpSigResult<Self> {
     // check if the order of component lines is the same as the order of covered message component ids
     if component_lines.len() != signature_params.covered_components.len() {
       return Err(HttpSigError::BuildSignatureBaseError(
@@ -167,7 +176,8 @@ impl HttpSignatureBase {
     }
 
     Ok(Self {
-      component_lines: component_lines.to_vec(),
+      component_lines,
+      // defer clone on happy path
       signature_params: signature_params.clone(),
     })
   }
@@ -261,16 +271,18 @@ mod test {
   /// こんな感じでSignatureBaseをParamsとかComponentLinesから直接作るのは避ける。
   #[test]
   fn test_signature_base_directly_instantiated() {
-    const SIGPARA: &str = r##";created=1704972031;alg="ed25519";keyid="gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=""##;
+    const SIGPARA: &str =
+      r##";created=1704972031;alg="ed25519";keyid="gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=""##;
     let values = (r##""@method" "@path" "date" "content-digest""##, SIGPARA);
-    let signature_params = HttpSignatureParams::try_from(format!("({}){}", values.0, values.1).as_str()).unwrap();
+    let signature_params =
+      HttpSignatureParams::try_from(format!("({}){}", values.0, values.1).as_str()).unwrap();
 
     let component_lines = COMPONENT_LINES
       .iter()
       .map(|&s| HttpMessageComponent::try_from(s))
       .collect::<Result<Vec<_>, _>>()
       .unwrap();
-    let signature_base = HttpSignatureBase::try_new(&component_lines, &signature_params).unwrap();
+    let signature_base = HttpSignatureBase::try_new(component_lines, &signature_params).unwrap();
     let test_string = r##""@method": GET
 "@path": /
 "date": Tue, 07 Jun 2014 20:51:35 GMT

--- a/httpsig/src/signature_base.rs
+++ b/httpsig/src/signature_base.rs
@@ -256,7 +256,7 @@ impl std::fmt::Display for HttpSignatureBase {
   }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "ed25519-signature"))]
 mod test {
   use super::*;
   use crate::signature_params::HttpSignatureParams;

--- a/httpsig/src/signature_params.rs
+++ b/httpsig/src/signature_params.rs
@@ -36,10 +36,13 @@ pub struct HttpSignatureParams {
 impl HttpSignatureParams {
   /// Create new HttpSignatureParams object for the given covered components only with `created`` current timestamp.
   pub fn try_new(covered_components: &[HttpMessageComponentId]) -> HttpSigResult<Self> {
-    let created = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+    let created = SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .unwrap()
+      .as_secs();
     if !has_unique_elements(covered_components.iter()) {
       return Err(HttpSigError::InvalidSignatureParams(
-        "duplicate covered component ids".to_string(),
+        "duplicate covered component ids",
       ));
     }
 
@@ -113,7 +116,11 @@ impl HttpSignatureParams {
   /// If `exp` field is not present, it always returns false.
   pub fn is_expired(&self) -> bool {
     if let Some(exp) = self.expires {
-      exp < SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()
+      exp
+        < SystemTime::now()
+          .duration_since(UNIX_EPOCH)
+          .unwrap()
+          .as_secs()
     } else {
       false
     }
@@ -122,13 +129,16 @@ impl HttpSignatureParams {
 
 impl std::fmt::Display for HttpSignatureParams {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    let joined = self.covered_components.iter().fold("".to_string(), |acc, v| {
-      if acc.is_empty() {
-        v.to_string()
-      } else {
-        format!("{acc} {v}")
-      }
-    });
+    let joined = self
+      .covered_components
+      .iter()
+      .fold("".to_string(), |acc, v| {
+        if acc.is_empty() {
+          v.to_string()
+        } else {
+          format!("{acc} {v}")
+        }
+      });
     let mut s: String = format!("({})", joined);
     if self.created.is_some() {
       s.push_str(&format!(";created={}", self.created.unwrap()));
@@ -157,7 +167,9 @@ impl TryFrom<&ListEntry> for HttpSignatureParams {
   /// Convert from ListEntry to HttpSignatureParams
   fn try_from(value: &ListEntry) -> HttpSigResult<Self> {
     if !matches!(value, ListEntry::InnerList(_)) {
-      return Err(HttpSigError::InvalidSignatureParams("Invalid signature params".to_string()));
+      return Err(HttpSigError::InvalidSignatureParams(
+        "Invalid signature params",
+      ));
     }
     let inner_list_with_params = match value {
       ListEntry::InnerList(v) => v,
@@ -176,7 +188,7 @@ impl TryFrom<&ListEntry> for HttpSignatureParams {
 
     if !has_unique_elements(covered_components.iter()) {
       return Err(HttpSigError::InvalidSignatureParams(
-        "duplicate covered component ids".to_string(),
+        "duplicate covered component ids",
       ));
     }
 
@@ -217,7 +229,9 @@ impl TryFrom<&str> for HttpSignatureParams {
       .map_err(|e| HttpSigError::ParseSFVError(e.to_string()))?;
     // let sfv_parsed = Parser::parse_list(value.as_bytes()).map_err(|e| HttpSigError::ParseSFVError(e.to_string()))?;
     if sfv_parsed.len() != 1 || !matches!(sfv_parsed[0], ListEntry::InnerList(_)) {
-      return Err(HttpSigError::InvalidSignatureParams("Invalid signature params".to_string()));
+      return Err(HttpSigError::InvalidSignatureParams(
+        "Invalid signature params",
+      ));
     }
     HttpSignatureParams::try_from(&sfv_parsed[0])
   }
@@ -286,7 +300,8 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
 
   #[test]
   fn test_from_string_signature_params_without_param() {
-    let value = r##"("@method" "@path" "@scheme" "@authority" "content-type" "date" "content-length")"##;
+    let value =
+      r##"("@method" "@path" "@scheme" "@authority" "content-type" "date" "content-length")"##;
     let params = HttpSignatureParams::try_from(value);
     assert!(params.is_ok());
     let params = params.unwrap();
@@ -301,7 +316,8 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
 
   #[test]
   fn test_from_string_signature_params() {
-    const SIGPARA: &str = r##";created=1704972031;alg="ed25519";keyid="gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=""##;
+    const SIGPARA: &str =
+      r##";created=1704972031;alg="ed25519";keyid="gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=""##;
     let values = vec![
       (
         r##""@method" "@path" "@scheme";req "@authority" "content-type";bs "date" "content-length""##,

--- a/httpsig/src/signature_params.rs
+++ b/httpsig/src/signature_params.rs
@@ -91,7 +91,10 @@ impl HttpSignatureParams {
 
   /// Set `keyid` and `alg` from the signing key
   pub fn set_key_info(&mut self, key: &impl SigningKey) -> &mut Self {
-    self.keyid = Some(key.key_id().to_string());
+    #[cfg(feature = "key-id")]
+    {
+      self.keyid = Some(key.key_id().to_string());
+    }
     self.alg = Some(key.alg().to_string());
     self
   }

--- a/httpsig/src/signature_params.rs
+++ b/httpsig/src/signature_params.rs
@@ -240,15 +240,19 @@ impl TryFrom<&str> for HttpSignatureParams {
 #[cfg(test)]
 mod tests {
   use super::*;
+  #[cfg(feature = "ed25519-signature")]
   use crate::crypto::SecretKey;
+  #[cfg(feature = "ed25519-signature")]
   const EDDSA_SECRET_KEY: &str = r##"-----BEGIN PRIVATE KEY-----
 MC4CAQAwBQYDK2VwBCIEIDSHAE++q1BP7T8tk+mJtS+hLf81B0o6CFyWgucDFN/C
 -----END PRIVATE KEY-----
 "##;
+  #[cfg(feature = "ed25519-signature")]
   const _EDDSA_PUBLIC_KEY: &str = r##"-----BEGIN PUBLIC KEY-----
 MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
 -----END PUBLIC KEY-----
 "##;
+  #[cfg(feature = "ed25519-signature")]
   const EDDSA_KEY_ID: &str = "gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=";
 
   fn build_covered_components() -> Vec<HttpMessageComponentId> {
@@ -277,6 +281,7 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
     assert_eq!(params.covered_components.len(), 7);
   }
 
+  #[cfg(feature = "ed25519-signature")]
   #[test]
   fn test_set_key_info() {
     let mut params = HttpSignatureParams::try_new(&build_covered_components()).unwrap();
@@ -314,6 +319,7 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
     assert_eq!(params.covered_components.len(), 7);
   }
 
+  #[cfg(feature = "ed25519-signature")]
   #[test]
   fn test_from_string_signature_params() {
     const SIGPARA: &str =


### PR DESCRIPTION
This PR builds on top of the configurable digest hash functions PRs.

Summary of changes:

- sequential CPU-bound `futures::future::join_all` are rewritten as simple loops
- runtime branching/RequestOrResponse enum is replaced by monomorphization/HttpMessage trait
- removed useless intermediate string allocations, take owned Strings instead of references where downstream code requires it
- errors use static strings where possible
- supported signature algorithms are configurable via Cargo features