### PR TITLE
chore: fix Rust formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+tab_spaces = 2

--- a/httpsig-hyper/examples/hyper-request.rs
+++ b/httpsig-hyper/examples/hyper-request.rs
@@ -28,7 +28,10 @@ async fn build_request() -> Request<BoxBody> {
     .header("content-type", "application/json-patch+json")
     .body(body)
     .unwrap();
-  req.set_content_digest(&ContentDigestType::Sha256).await.unwrap()
+  req
+    .set_content_digest(&ContentDigestType::Sha256)
+    .await
+    .unwrap()
 }
 
 /// Sender function that generates a request with a signature
@@ -65,7 +68,8 @@ async fn sender_hs256(req: &mut Request<BoxBody>) {
   let mut signature_params = HttpSignatureParams::try_new(&covered_components).unwrap();
 
   // set signing/verifying key information, alg and keyid and random noce with hmac-sha256
-  let shared_key = SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
+  let shared_key =
+    SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
   signature_params.set_key_info(&shared_key);
   signature_params.set_random_nonce();
 
@@ -85,7 +89,9 @@ where
   let key_id = public_key.key_id();
 
   // verify signature with checking key_id
-  req.verify_message_signature(&public_key, Some(&key_id)).await
+  req
+    .verify_message_signature(&public_key, Some(&key_id))
+    .await
 }
 
 /// Receiver function that verifies a request with a signature of hmac-sha256
@@ -94,18 +100,24 @@ where
   B: http_body::Body + Send + Sync,
 {
   println!("Verifying HMAC-SHA256 signature");
-  let shared_key = SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
+  let shared_key =
+    SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
   let key_id = VerifyingKey::key_id(&shared_key);
 
   // verify signature with checking key_id
-  req.verify_message_signature(&shared_key, Some(&key_id)).await
+  req
+    .verify_message_signature(&shared_key, Some(&key_id))
+    .await
 }
 
 async fn scenario_multiple_signatures() {
   println!("--------------  Scenario: Multiple signatures  --------------");
 
   let mut request_from_sender = build_request().await;
-  println!("Request header before signing:\n{:#?}", request_from_sender.headers());
+  println!(
+    "Request header before signing:\n{:#?}",
+    request_from_sender.headers()
+  );
 
   // sender signs a signature of ed25519 and hmac-sha256
   sender_ed25519(&mut request_from_sender).await;
@@ -130,9 +142,15 @@ async fn scenario_multiple_signatures() {
     .map(|v| v.to_str())
     .collect::<Result<Vec<_>, _>>()
     .unwrap();
-  assert!(signature_inputs.iter().any(|v| v.starts_with(r##"siged25519=("##)));
-  assert!(signature_inputs.iter().any(|v| v.starts_with(r##"sighs256=("##)));
-  assert!(signatures.iter().any(|v| v.starts_with(r##"siged25519=:"##)));
+  assert!(signature_inputs
+    .iter()
+    .any(|v| v.starts_with(r##"siged25519=("##)));
+  assert!(signature_inputs
+    .iter()
+    .any(|v| v.starts_with(r##"sighs256=("##)));
+  assert!(signatures
+    .iter()
+    .any(|v| v.starts_with(r##"siged25519=:"##)));
   assert!(signatures.iter().any(|v| v.starts_with(r##"sighs256=:"##)));
 
   // receiver verifies the request with signatures
@@ -154,12 +172,18 @@ async fn scenario_single_signature_ed25519() {
   println!("--------------  Scenario: Single signature with Ed25519  --------------");
 
   let mut request_from_sender = build_request().await;
-  println!("Request header before signing:\n{:#?}", request_from_sender.headers());
+  println!(
+    "Request header before signing:\n{:#?}",
+    request_from_sender.headers()
+  );
 
   // sender signs a signature of ed25519
   sender_ed25519(&mut request_from_sender).await;
 
-  println!("Request header signed by ED25519:\n{:#?}", request_from_sender.headers());
+  println!(
+    "Request header signed by ED25519:\n{:#?}",
+    request_from_sender.headers()
+  );
 
   let signature_inputs = request_from_sender
     .headers()
@@ -175,8 +199,12 @@ async fn scenario_single_signature_ed25519() {
     .map(|v| v.to_str())
     .collect::<Result<Vec<_>, _>>()
     .unwrap();
-  assert!(signature_inputs.iter().any(|v| v.starts_with(r##"siged25519=("##)));
-  assert!(signatures.iter().any(|v| v.starts_with(r##"siged25519=:"##)));
+  assert!(signature_inputs
+    .iter()
+    .any(|v| v.starts_with(r##"siged25519=("##)));
+  assert!(signatures
+    .iter()
+    .any(|v| v.starts_with(r##"siged25519=:"##)));
 
   // receiver verifies the request with signatures
   // every signature is independent and verified separately

--- a/httpsig-hyper/examples/hyper-response.rs
+++ b/httpsig-hyper/examples/hyper-response.rs
@@ -16,7 +16,13 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
 const HMACSHA256_SECRET_KEY: &str =
   r##"uzvJfB4u3N0Jy4T7NZ75MDVcr8zSTInedJtkgcu46YW4XByzNJjxBdtjUkdJPBtbmHhIDi6pcl8jsasjlTMtDQ=="##;
 
-const COVERED_COMPONENTS: &[&str] = &["@status", "\"@method\";req", "date", "content-type", "\"content-digest\";req"];
+const COVERED_COMPONENTS: &[&str] = &[
+  "@status",
+  "\"@method\";req",
+  "date",
+  "content-type",
+  "\"content-digest\";req",
+];
 
 async fn build_request() -> Request<BoxBody> {
   let body = Full::new(&b"{\"hello\": \"world\"}"[..]);
@@ -28,7 +34,10 @@ async fn build_request() -> Request<BoxBody> {
     .header("content-type", "application/json-patch+json")
     .body(body)
     .unwrap();
-  req.set_content_digest(&ContentDigestType::Sha256).await.unwrap()
+  req
+    .set_content_digest(&ContentDigestType::Sha256)
+    .await
+    .unwrap()
 }
 
 async fn build_response() -> Response<BoxBody> {
@@ -40,7 +49,10 @@ async fn build_response() -> Response<BoxBody> {
     .header("content-type", "application/json-patch+json")
     .body(body)
     .unwrap();
-  res.set_content_digest(&ContentDigestType::Sha256).await.unwrap()
+  res
+    .set_content_digest(&ContentDigestType::Sha256)
+    .await
+    .unwrap()
 }
 
 /// Sender function that generates a request with a signature
@@ -60,7 +72,12 @@ async fn sender_ed25519(res: &mut Response<BoxBody>, received_req: &Request<BoxB
 
   // set signature with custom signature name
   res
-    .set_message_signature(&signature_params, &secret_key, Some("siged25519"), Some(received_req))
+    .set_message_signature(
+      &signature_params,
+      &secret_key,
+      Some("siged25519"),
+      Some(received_req),
+    )
     .await
     .unwrap();
 }
@@ -77,18 +94,27 @@ async fn sender_hs256(res: &mut Response<BoxBody>, received_req: &Request<BoxBod
   let mut signature_params = HttpSignatureParams::try_new(&covered_components).unwrap();
 
   // set signing/verifying key information, alg and keyid and random noce with hmac-sha256
-  let shared_key = SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
+  let shared_key =
+    SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
   signature_params.set_key_info(&shared_key);
   signature_params.set_random_nonce();
 
   res
-    .set_message_signature(&signature_params, &shared_key, Some("sighs256"), Some(received_req))
+    .set_message_signature(
+      &signature_params,
+      &shared_key,
+      Some("sighs256"),
+      Some(received_req),
+    )
     .await
     .unwrap();
 }
 
 /// Receiver function that verifies a request with a signature of ed25519
-async fn receiver_ed25519<B>(res: &Response<B>, sent_req: &Request<BoxBody>) -> HyperSigResult<SignatureName>
+async fn receiver_ed25519<B>(
+  res: &Response<B>,
+  sent_req: &Request<BoxBody>,
+) -> HyperSigResult<SignatureName>
 where
   B: http_body::Body + Send + Sync,
 {
@@ -97,20 +123,28 @@ where
   let key_id = public_key.key_id();
 
   // verify signature with checking key_id
-  res.verify_message_signature(&public_key, Some(&key_id), Some(sent_req)).await
+  res
+    .verify_message_signature(&public_key, Some(&key_id), Some(sent_req))
+    .await
 }
 
 /// Receiver function that verifies a request with a signature of hmac-sha256
-async fn receiver_hmac_sha256<B>(res: &Response<B>, sent_req: &Request<BoxBody>) -> HyperSigResult<SignatureName>
+async fn receiver_hmac_sha256<B>(
+  res: &Response<B>,
+  sent_req: &Request<BoxBody>,
+) -> HyperSigResult<SignatureName>
 where
   B: http_body::Body + Send + Sync,
 {
   println!("Verifying HMAC-SHA256 signature");
-  let shared_key = SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
+  let shared_key =
+    SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
   let key_id = VerifyingKey::key_id(&shared_key);
 
   // verify signature with checking key_id
-  res.verify_message_signature(&shared_key, Some(&key_id), Some(sent_req)).await
+  res
+    .verify_message_signature(&shared_key, Some(&key_id), Some(sent_req))
+    .await
 }
 
 async fn scenario_multiple_signatures() {
@@ -120,7 +154,10 @@ async fn scenario_multiple_signatures() {
   println!("Header of request received:\n{:#?}", sent_req.headers());
 
   let mut response_from_sender = build_response().await;
-  println!("Request header before signing:\n{:#?}", response_from_sender.headers());
+  println!(
+    "Request header before signing:\n{:#?}",
+    response_from_sender.headers()
+  );
 
   // sender signs a signature of ed25519 and hmac-sha256
   sender_ed25519(&mut response_from_sender, &sent_req).await;
@@ -145,9 +182,15 @@ async fn scenario_multiple_signatures() {
     .map(|v| v.to_str())
     .collect::<Result<Vec<_>, _>>()
     .unwrap();
-  assert!(signature_inputs.iter().any(|v| v.starts_with(r##"siged25519=("##)));
-  assert!(signature_inputs.iter().any(|v| v.starts_with(r##"sighs256=("##)));
-  assert!(signatures.iter().any(|v| v.starts_with(r##"siged25519=:"##)));
+  assert!(signature_inputs
+    .iter()
+    .any(|v| v.starts_with(r##"siged25519=("##)));
+  assert!(signature_inputs
+    .iter()
+    .any(|v| v.starts_with(r##"sighs256=("##)));
+  assert!(signatures
+    .iter()
+    .any(|v| v.starts_with(r##"siged25519=:"##)));
   assert!(signatures.iter().any(|v| v.starts_with(r##"sighs256=:"##)));
 
   // receiver verifies the request with signatures
@@ -172,12 +215,18 @@ async fn scenario_single_signature_ed25519() {
   println!("Header of request received:\n{:#?}", sent_req.headers());
 
   let mut response_from_sender = build_response().await;
-  println!("Response header before signing:\n{:#?}", response_from_sender.headers());
+  println!(
+    "Response header before signing:\n{:#?}",
+    response_from_sender.headers()
+  );
 
   // sender signs a signature of ed25519
   sender_ed25519(&mut response_from_sender, &sent_req).await;
 
-  println!("Response header signed by ED25519:\n{:#?}", response_from_sender.headers());
+  println!(
+    "Response header signed by ED25519:\n{:#?}",
+    response_from_sender.headers()
+  );
 
   let signature_inputs = response_from_sender
     .headers()
@@ -193,8 +242,12 @@ async fn scenario_single_signature_ed25519() {
     .map(|v| v.to_str())
     .collect::<Result<Vec<_>, _>>()
     .unwrap();
-  assert!(signature_inputs.iter().any(|v| v.starts_with(r##"siged25519=("##)));
-  assert!(signatures.iter().any(|v| v.starts_with(r##"siged25519=:"##)));
+  assert!(signature_inputs
+    .iter()
+    .any(|v| v.starts_with(r##"siged25519=("##)));
+  assert!(signatures
+    .iter()
+    .any(|v| v.starts_with(r##"siged25519=:"##)));
 
   // receiver verifies the request with signatures
   // every signature is independent and verified separately

--- a/httpsig-hyper/src/hyper_content_digest.rs
+++ b/httpsig-hyper/src/hyper_content_digest.rs
@@ -75,7 +75,9 @@ pub trait RequestContentDigest {
     Self: Sized;
 
   /// Verify the content digest in the request and returns self if it's valid otherwise returns error
-  fn verify_content_digest(self) -> impl Future<Output = Result<Self::PassthroughRequest, Self::Error>> + Send
+  fn verify_content_digest(
+    self,
+  ) -> impl Future<Output = Result<Self::PassthroughRequest, Self::Error>> + Send
   where
     Self: Sized;
 }
@@ -94,7 +96,9 @@ pub trait ResponseContentDigest {
     Self: Sized;
 
   /// Verify the content digest in the response and returns self if it's valid otherwise returns error
-  fn verify_content_digest(self) -> impl Future<Output = Result<Self::PassthroughResponse, Self::Error>> + Send
+  fn verify_content_digest(
+    self,
+  ) -> impl Future<Output = Result<Self::PassthroughResponse, Self::Error>> + Send
   where
     Self: Sized;
 }
@@ -108,7 +112,10 @@ where
   type PassthroughRequest = Request<BoxBody<Bytes, Self::Error>>;
 
   /// Set the content digest in the request
-  async fn set_content_digest(self, cd_type: &ContentDigestType) -> HyperDigestResult<Self::PassthroughRequest>
+  async fn set_content_digest(
+    self,
+    cd_type: &ContentDigestType,
+  ) -> HyperDigestResult<Self::PassthroughRequest>
   where
     Self: Sized,
   {
@@ -117,11 +124,14 @@ where
       .into_bytes_with_digest(cd_type)
       .await
       .map_err(|_e| HyperDigestError::HttpBodyError("Failed to generate digest".to_string()))?;
-    let new_body = Full::new(body_bytes).map_err(|never| match never {}).boxed();
+    let new_body = Full::new(body_bytes)
+      .map_err(|never| match never {})
+      .boxed();
 
-    parts
-      .headers
-      .insert(CONTENT_DIGEST_HEADER, format!("{cd_type}=:{digest}:").parse().unwrap());
+    parts.headers.insert(
+      CONTENT_DIGEST_HEADER,
+      format!("{cd_type}=:{digest}:").parse().unwrap(),
+    );
 
     let new_req = Request::from_parts(parts, new_body);
     Ok(new_req)
@@ -144,7 +154,9 @@ where
 
     // Use constant time equality check to prevent timing attacks
     if is_equal_digest(&digest, &expected_digest) {
-      let new_body = Full::new(body_bytes).map_err(|never| match never {}).boxed();
+      let new_body = Full::new(body_bytes)
+        .map_err(|never| match never {})
+        .boxed();
       let res = Request::from_parts(header, new_body);
       Ok(res)
     } else {
@@ -163,7 +175,10 @@ where
   type Error = HyperDigestError;
   type PassthroughResponse = Response<BoxBody<Bytes, Self::Error>>;
 
-  async fn set_content_digest(self, cd_type: &ContentDigestType) -> HyperDigestResult<Self::PassthroughResponse>
+  async fn set_content_digest(
+    self,
+    cd_type: &ContentDigestType,
+  ) -> HyperDigestResult<Self::PassthroughResponse>
   where
     Self: Sized,
   {
@@ -172,11 +187,14 @@ where
       .into_bytes_with_digest(cd_type)
       .await
       .map_err(|_e| HyperDigestError::HttpBodyError("Failed to generate digest".to_string()))?;
-    let new_body = Full::new(body_bytes).map_err(|never| match never {}).boxed();
+    let new_body = Full::new(body_bytes)
+      .map_err(|never| match never {})
+      .boxed();
 
-    parts
-      .headers
-      .insert(CONTENT_DIGEST_HEADER, format!("{cd_type}=:{digest}:").parse().unwrap());
+    parts.headers.insert(
+      CONTENT_DIGEST_HEADER,
+      format!("{cd_type}=:{digest}:").parse().unwrap(),
+    );
 
     let new_req = Response::from_parts(parts, new_body);
     Ok(new_req)
@@ -196,7 +214,9 @@ where
 
     // Use constant time equality check to prevent timing attacks
     if is_equal_digest(&digest, &expected_digest) {
-      let new_body = Full::new(body_bytes).map_err(|never| match never {}).boxed();
+      let new_body = Full::new(body_bytes)
+        .map_err(|never| match never {})
+        .boxed();
       let res = Response::from_parts(header, new_body);
       Ok(res)
     } else {
@@ -217,10 +237,14 @@ fn is_equal_digest(digest1: &[u8], digest2: &[u8]) -> bool {
   digest1.ct_eq(digest2).into()
 }
 
-async fn extract_content_digest(header_map: &http::HeaderMap) -> HyperDigestResult<(ContentDigestType, Vec<u8>)> {
+async fn extract_content_digest(
+  header_map: &http::HeaderMap,
+) -> HyperDigestResult<(ContentDigestType, Vec<u8>)> {
   let content_digest_header = header_map
     .get(CONTENT_DIGEST_HEADER)
-    .ok_or(HyperDigestError::NoDigestHeader("No content-digest header".to_string()))?
+    .ok_or(HyperDigestError::NoDigestHeader(
+      "No content-digest header".to_string(),
+    ))?
     .to_str()?;
   let indexmap = sfv::Parser::new(content_digest_header)
     .parse::<sfv::Dictionary>()
@@ -231,8 +255,9 @@ async fn extract_content_digest(header_map: &http::HeaderMap) -> HyperDigestResu
     ));
   };
   let (cd_type, cd) = indexmap.iter().next().unwrap();
-  let cd_type = ContentDigestType::from_str(cd_type.as_str())
-    .map_err(|e| HyperDigestError::InvalidHeaderValue(format!("Invalid Content-Digest type: {e}")))?;
+  let cd_type = ContentDigestType::from_str(cd_type.as_str()).map_err(|e| {
+    HyperDigestError::InvalidHeaderValue(format!("Invalid Content-Digest type: {e}"))
+  })?;
   if !matches!(
     cd,
     sfv::ListEntry::Item(sfv::Item {
@@ -263,11 +288,17 @@ mod tests {
   #[tokio::test]
   async fn content_digest() {
     let body = Full::new(&b"{\"hello\": \"world\"}"[..]);
-    let (_body_bytes, digest) = body.into_bytes_with_digest(&ContentDigestType::Sha256).await.unwrap();
+    let (_body_bytes, digest) = body
+      .into_bytes_with_digest(&ContentDigestType::Sha256)
+      .await
+      .unwrap();
 
     assert_eq!(digest, "X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=");
 
-    let (_body_bytes, digest) = body.into_bytes_with_digest(&ContentDigestType::Sha512).await.unwrap();
+    let (_body_bytes, digest) = body
+      .into_bytes_with_digest(&ContentDigestType::Sha512)
+      .await
+      .unwrap();
     assert_eq!(
       digest,
       "WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew=="
@@ -285,11 +316,22 @@ mod tests {
       .header("content-type", "application/json")
       .body(body)
       .unwrap();
-    let req = req.set_content_digest(&ContentDigestType::Sha256).await.unwrap();
+    let req = req
+      .set_content_digest(&ContentDigestType::Sha256)
+      .await
+      .unwrap();
 
     assert!(req.headers().contains_key(CONTENT_DIGEST_HEADER));
-    let digest = req.headers().get(CONTENT_DIGEST_HEADER).unwrap().to_str().unwrap();
-    assert_eq!(digest, format!("sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:"));
+    let digest = req
+      .headers()
+      .get(CONTENT_DIGEST_HEADER)
+      .unwrap()
+      .to_str()
+      .unwrap();
+    assert_eq!(
+      digest,
+      format!("sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:")
+    );
 
     let verified = req.verify_content_digest().await;
     assert!(verified.is_ok());
@@ -305,11 +347,22 @@ mod tests {
       .header("content-type", "application/json")
       .body(body)
       .unwrap();
-    let res = res.set_content_digest(&ContentDigestType::Sha256).await.unwrap();
+    let res = res
+      .set_content_digest(&ContentDigestType::Sha256)
+      .await
+      .unwrap();
 
     assert!(res.headers().contains_key(CONTENT_DIGEST_HEADER));
-    let digest = res.headers().get(CONTENT_DIGEST_HEADER).unwrap().to_str().unwrap();
-    assert_eq!(digest, format!("sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:"));
+    let digest = res
+      .headers()
+      .get(CONTENT_DIGEST_HEADER)
+      .unwrap()
+      .to_str()
+      .unwrap();
+    assert_eq!(
+      digest,
+      format!("sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:")
+    );
 
     let verified = res.verify_content_digest().await;
     assert!(verified.is_ok());
@@ -327,7 +380,10 @@ mod tests {
       .body(body)
       .unwrap();
 
-    let req = req.set_content_digest(&ContentDigestType::Sha256).await.unwrap();
+    let req = req
+      .set_content_digest(&ContentDigestType::Sha256)
+      .await
+      .unwrap();
     assert!(req.headers().contains_key(CONTENT_DIGEST_HEADER));
 
     // 2) Tamper the body while keeping the digest header unchanged
@@ -355,7 +411,10 @@ mod tests {
       .body(body)
       .unwrap();
 
-    let res = res.set_content_digest(&ContentDigestType::Sha256).await.unwrap();
+    let res = res
+      .set_content_digest(&ContentDigestType::Sha256)
+      .await
+      .unwrap();
     let (mut parts, body) = res.into_parts();
 
     // 2) Tamper the Content-Digest header (keep it syntactically valid)
@@ -363,7 +422,9 @@ mod tests {
     // Change the first character to another valid base64 character.
     parts.headers.insert(
       CONTENT_DIGEST_HEADER,
-      "sha-256=:Y48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:".parse().unwrap(),
+      "sha-256=:Y48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:"
+        .parse()
+        .unwrap(),
     );
 
     let tampered_res = Response::from_parts(parts, body);
@@ -409,7 +470,10 @@ mod tests {
       .body(body)
       .unwrap();
 
-    let req = req.set_content_digest(&ContentDigestType::Sha256).await.unwrap();
+    let req = req
+      .set_content_digest(&ContentDigestType::Sha256)
+      .await
+      .unwrap();
 
     // 2) Extract parts and replace the Content-Digest header
     //    with a syntactically valid but length-mismatched base64 value.

--- a/httpsig-hyper/src/hyper_http.rs
+++ b/httpsig-hyper/src/hyper_http.rs
@@ -3,9 +3,11 @@ use http::{HeaderMap, Request, Response};
 use http_body::Body;
 use httpsig::prelude::{
   message_component::{
-    DerivedComponentName, HttpMessageComponent, HttpMessageComponentId, HttpMessageComponentName, HttpMessageComponentParam,
+    DerivedComponentName, HttpMessageComponent, HttpMessageComponentId, HttpMessageComponentName,
+    HttpMessageComponentParam,
   },
-  AlgorithmName, HttpSignatureBase, HttpSignatureHeaders, HttpSignatureHeadersMap, HttpSignatureParams, SigningKey, VerifyingKey,
+  AlgorithmName, HttpSignatureBase, HttpSignatureHeaders, HttpSignatureHeadersMap,
+  HttpSignatureParams, SigningKey, VerifyingKey,
 };
 use indexmap::{IndexMap, IndexSet};
 use std::{future::Future, str::FromStr};
@@ -24,10 +26,14 @@ pub trait MessageSignature {
   fn has_message_signature(&self) -> bool;
 
   /// Extract all key ids for signature bases contained in the request headers
-  fn get_alg_key_ids(&self) -> Result<IndexMap<SignatureName, (Option<AlgorithmName>, Option<KeyId>)>, Self::Error>;
+  fn get_alg_key_ids(
+    &self,
+  ) -> Result<IndexMap<SignatureName, (Option<AlgorithmName>, Option<KeyId>)>, Self::Error>;
 
   /// Extract all signature params used to generate signature bases contained in the request headers
-  fn get_signature_params(&self) -> Result<IndexMap<SignatureName, HttpSignatureParams>, Self::Error>;
+  fn get_signature_params(
+    &self,
+  ) -> Result<IndexMap<SignatureName, HttpSignatureParams>, Self::Error>;
 }
 
 /// A trait about http message signature for request
@@ -73,7 +79,9 @@ pub trait MessageSignatureReq {
     T: VerifyingKey + Sync;
 
   /// Extract all signature bases contained in the request headers
-  fn extract_signatures(&self) -> Result<IndexMap<SignatureName, (HttpSignatureBase, HttpSignatureHeaders)>, Self::Error>;
+  fn extract_signatures(
+    &self,
+  ) -> Result<IndexMap<SignatureName, (HttpSignatureBase, HttpSignatureHeaders)>, Self::Error>;
 }
 
 /// A trait about http message signature for response
@@ -162,7 +170,11 @@ pub trait MessageSignatureReqSync: MessageSignatureReq {
     Self: Sized,
     T: SigningKey + Sync;
 
-  fn verify_message_signature_sync<T>(&self, verifying_key: &T, key_id: Option<&str>) -> Result<SignatureName, Self::Error>
+  fn verify_message_signature_sync<T>(
+    &self,
+    verifying_key: &T,
+    key_id: Option<&str>,
+  ) -> Result<SignatureName, Self::Error>
   where
     Self: Sized,
     T: VerifyingKey + Sync;
@@ -243,13 +255,17 @@ where
   }
 
   /// Extract all signature bases contained in the request headers
-  fn get_alg_key_ids(&self) -> HyperSigResult<IndexMap<SignatureName, (Option<AlgorithmName>, Option<KeyId>)>> {
+  fn get_alg_key_ids(
+    &self,
+  ) -> HyperSigResult<IndexMap<SignatureName, (Option<AlgorithmName>, Option<KeyId>)>> {
     let req_or_res = RequestOrResponse::Request(self);
     get_alg_key_ids_inner(&req_or_res)
   }
 
   /// Extract all signature params used to generate signature bases contained in the request headers
-  fn get_signature_params(&self) -> Result<IndexMap<SignatureName, HttpSignatureParams>, Self::Error> {
+  fn get_signature_params(
+    &self,
+  ) -> Result<IndexMap<SignatureName, HttpSignatureParams>, Self::Error> {
     let req_or_res = RequestOrResponse::Request(self);
     get_signature_params_inner(&req_or_res)
   }
@@ -289,7 +305,8 @@ where
     let vec_signature_bases = params_key_name
       .iter()
       .map(|(params, key, name)| {
-        build_signature_base(&req_or_res, params, None as Option<&Request<()>>).map(|base| (base, *key, *name))
+        build_signature_base(&req_or_res, params, None as Option<&Request<()>>)
+          .map(|base| (base, *key, *name))
       })
       .collect::<Result<Vec<_>, _>>()?;
     let vec_signature_headers = futures::future::join_all(
@@ -301,9 +318,10 @@ where
     .into_iter()
     .collect::<Result<Vec<_>, _>>()?;
     vec_signature_headers.iter().try_for_each(|headers| {
-      self
-        .headers_mut()
-        .append("signature-input", headers.signature_input_header_value().parse()?);
+      self.headers_mut().append(
+        "signature-input",
+        headers.signature_input_header_value().parse()?,
+      );
       self
         .headers_mut()
         .append("signature", headers.signature_header_value().parse()?);
@@ -315,7 +333,11 @@ where
   /// Return Ok(()) if the signature is valid.
   /// If invalid for the given key or error occurs (like the case where the request does not have signature and/or signature-input headers), return Err.
   /// If key_id is given, it is used to match the key id in signature params
-  async fn verify_message_signature<T>(&self, verifying_key: &T, key_id: Option<&str>) -> HyperSigResult<SignatureName>
+  async fn verify_message_signature<T>(
+    &self,
+    verifying_key: &T,
+    key_id: Option<&str>,
+  ) -> HyperSigResult<SignatureName>
   where
     Self: Sized,
     T: VerifyingKey + Sync,
@@ -345,7 +367,9 @@ where
   }
 
   /// Extract all signature bases contained in the request headers
-  fn extract_signatures(&self) -> Result<IndexMap<SignatureName, (HttpSignatureBase, HttpSignatureHeaders)>, Self::Error> {
+  fn extract_signatures(
+    &self,
+  ) -> Result<IndexMap<SignatureName, (HttpSignatureBase, HttpSignatureHeaders)>, Self::Error> {
     let req_or_res = RequestOrResponse::Request(self);
     extract_signatures_inner(&req_or_res, None as Option<&Request<()>>)
   }
@@ -364,13 +388,17 @@ where
   }
 
   /// Extract all key ids for signature bases contained in the response headers
-  fn get_alg_key_ids(&self) -> Result<IndexMap<SignatureName, (Option<AlgorithmName>, Option<KeyId>)>, Self::Error> {
+  fn get_alg_key_ids(
+    &self,
+  ) -> Result<IndexMap<SignatureName, (Option<AlgorithmName>, Option<KeyId>)>, Self::Error> {
     let req_or_res = RequestOrResponse::Response(self);
     get_alg_key_ids_inner(&req_or_res)
   }
 
   /// Extract all signature params used to generate signature bases contained in the response headers
-  fn get_signature_params(&self) -> Result<IndexMap<SignatureName, HttpSignatureParams>, Self::Error> {
+  fn get_signature_params(
+    &self,
+  ) -> Result<IndexMap<SignatureName, HttpSignatureParams>, Self::Error> {
     let req_or_res = RequestOrResponse::Response(self);
     get_signature_params_inner(&req_or_res)
   }
@@ -396,7 +424,10 @@ where
     B: Sync,
   {
     self
-      .set_message_signatures(&[(signature_params, signing_key, signature_name)], req_for_param)
+      .set_message_signatures(
+        &[(signature_params, signing_key, signature_name)],
+        req_for_param,
+      )
       .await
   }
 
@@ -413,7 +444,9 @@ where
 
     let vec_signature_bases = params_key_name
       .iter()
-      .map(|(params, key, name)| build_signature_base(&req_or_res, params, req_for_param).map(|base| (base, *key, *name)))
+      .map(|(params, key, name)| {
+        build_signature_base(&req_or_res, params, req_for_param).map(|base| (base, *key, *name))
+      })
       .collect::<Result<Vec<_>, _>>()?;
     let vec_signature_headers = futures::future::join_all(
       vec_signature_bases
@@ -425,9 +458,10 @@ where
     .collect::<Result<Vec<_>, _>>()?;
 
     vec_signature_headers.iter().try_for_each(|headers| {
-      self
-        .headers_mut()
-        .append("signature-input", headers.signature_input_header_value().parse()?);
+      self.headers_mut().append(
+        "signature-input",
+        headers.signature_input_header_value().parse()?,
+      );
       self
         .headers_mut()
         .append("signature", headers.signature_header_value().parse()?);
@@ -501,7 +535,11 @@ where
     Self: Sized,
     T: SigningKey + Sync,
   {
-    futures::executor::block_on(self.set_message_signature(signature_params, signing_key, signature_name))
+    futures::executor::block_on(self.set_message_signature(
+      signature_params,
+      signing_key,
+      signature_name,
+    ))
   }
 
   fn set_message_signatures_sync<T>(
@@ -515,7 +553,11 @@ where
     futures::executor::block_on(self.set_message_signatures(params_key_name))
   }
 
-  fn verify_message_signature_sync<T>(&self, verifying_key: &T, key_id: Option<&str>) -> Result<SignatureName, Self::Error>
+  fn verify_message_signature_sync<T>(
+    &self,
+    verifying_key: &T,
+    key_id: Option<&str>,
+  ) -> Result<SignatureName, Self::Error>
   where
     Self: Sized,
     T: VerifyingKey + Sync,
@@ -552,7 +594,12 @@ where
     T: SigningKey + Sync,
     B: Sync,
   {
-    futures::executor::block_on(self.set_message_signature(signature_params, signing_key, signature_name, req_for_param))
+    futures::executor::block_on(self.set_message_signature(
+      signature_params,
+      signing_key,
+      signature_name,
+      req_for_param,
+    ))
   }
 
   fn set_message_signatures_sync<T, B>(
@@ -685,7 +732,12 @@ where
       // check if any one of the signature headers is valid
       let successful_sig_names = filtered
         .iter()
-        .filter_map(|(&name, (base, headers))| base.verify_signature_headers(*key, headers).ok().map(|_| name.clone()))
+        .filter_map(|(&name, (base, headers))| {
+          base
+            .verify_signature_headers(*key, headers)
+            .ok()
+            .map(|_| name.clone())
+        })
         .collect::<IndexSet<_>>();
       if !successful_sig_names.is_empty() {
         Ok(successful_sig_names.first().unwrap().clone())
@@ -721,7 +773,9 @@ impl<B> RequestOrResponse<'_, B> {
   fn uri(&self) -> HyperSigResult<&http::Uri> {
     match self {
       RequestOrResponse::Request(req) => Ok(req.uri()),
-      _ => Err(HyperSigError::InvalidComponentName("`uri` is only for request".to_string())),
+      _ => Err(HyperSigError::InvalidComponentName(
+        "`uri` is only for request".to_string(),
+      )),
     }
   }
 
@@ -743,7 +797,9 @@ impl<B> RequestOrResponse<'_, B> {
 }
 
 /// Extract signature and signature-input with signature-name indication from http request and response
-fn extract_signature_headers_with_name<B>(req_or_res: &RequestOrResponse<B>) -> HyperSigResult<HttpSignatureHeadersMap> {
+fn extract_signature_headers_with_name<B>(
+  req_or_res: &RequestOrResponse<B>,
+) -> HyperSigResult<HttpSignatureHeadersMap> {
   let headers = req_or_res.headers();
   if !(headers.contains_key("signature-input") && headers.contains_key("signature")) {
     return Err(HyperSigError::NoSignatureHeaders(
@@ -764,7 +820,8 @@ fn extract_signature_headers_with_name<B>(req_or_res: &RequestOrResponse<B>) -> 
     .collect::<Result<Vec<_>, _>>()?
     .join(", ");
 
-  let signature_headers = HttpSignatureHeaders::try_parse(&signature_strings, &signature_input_strings)?;
+  let signature_headers =
+    HttpSignatureHeaders::try_parse(&signature_strings, &signature_input_strings)?;
   Ok(signature_headers)
 }
 
@@ -781,7 +838,11 @@ fn build_signature_base<B1, B2>(
     .covered_components
     .iter()
     .map(|component_id| {
-      if component_id.params.0.contains(&HttpMessageComponentParam::Req) {
+      if component_id
+        .params
+        .0
+        .contains(&HttpMessageComponentParam::Req)
+      {
         if matches!(req_or_res, RequestOrResponse::Request(_)) {
           return Err(HyperSigError::InvalidComponentParam(
             "`req` is not allowed in request".to_string(),
@@ -804,7 +865,10 @@ fn build_signature_base<B1, B2>(
 }
 
 /// Extract http field from hyper http request/response
-fn extract_http_field<B>(req_or_res: &RequestOrResponse<B>, id: &HttpMessageComponentId) -> HyperSigResult<HttpMessageComponent> {
+fn extract_http_field<B>(
+  req_or_res: &RequestOrResponse<B>,
+  id: &HttpMessageComponentId,
+) -> HyperSigResult<HttpMessageComponent> {
   let HttpMessageComponentName::HttpField(header_name) = &id.name else {
     return Err(HyperSigError::InvalidComponentName(
       "invalid http message component name as http field".to_string(),
@@ -839,7 +903,11 @@ fn extract_derived_component<B>(
   // - `req`: only valid on response messages (to reference request-derived components, §2.4)
   // - `sf`, `key`, `bs`, `tr`: only valid on HTTP field components, not derived components
   id.params.0.iter().try_for_each(|param| match param {
-    HttpMessageComponentParam::Name(_) if matches!(derived_id, DerivedComponentName::QueryParam) => Ok(()),
+    HttpMessageComponentParam::Name(_)
+      if matches!(derived_id, DerivedComponentName::QueryParam) =>
+    {
+      Ok(())
+    }
     HttpMessageComponentParam::Name(_) => Err(HyperSigError::InvalidComponentParam(
       "`name` parameter is only allowed for `@query-param`".to_string(),
     )),
@@ -889,10 +957,18 @@ fn extract_derived_component<B>(
   let field_values: Vec<String> = match derived_id {
     DerivedComponentName::Method => vec![req_or_res.method()?.as_str().to_string()],
     DerivedComponentName::TargetUri => vec![req_or_res.uri()?.to_string()],
-    DerivedComponentName::Authority => vec![req_or_res.uri()?.authority().map(|s| s.to_string()).unwrap_or("".to_string())],
+    DerivedComponentName::Authority => vec![req_or_res
+      .uri()?
+      .authority()
+      .map(|s| s.to_string())
+      .unwrap_or("".to_string())],
     DerivedComponentName::Scheme => vec![req_or_res.uri()?.scheme_str().unwrap_or("").to_string()],
     DerivedComponentName::RequestTarget => match *req_or_res.method()? {
-      http::Method::CONNECT => vec![req_or_res.uri()?.authority().map(|s| s.to_string()).unwrap_or("".to_string())],
+      http::Method::CONNECT => vec![req_or_res
+        .uri()?
+        .authority()
+        .map(|s| s.to_string())
+        .unwrap_or("".to_string())],
       http::Method::OPTIONS => vec!["*".to_string()],
       _ => vec![req_or_res
         .uri()?
@@ -908,7 +984,11 @@ fn extract_derived_component<B>(
         p.to_string()
       }
     }],
-    DerivedComponentName::Query => vec![req_or_res.uri()?.query().map(|v| format!("?{v}")).unwrap_or("?".to_string())],
+    DerivedComponentName::Query => vec![req_or_res
+      .uri()?
+      .query()
+      .map(|v| format!("?{v}"))
+      .unwrap_or("?".to_string())],
     DerivedComponentName::QueryParam => {
       let query = req_or_res.uri()?.query().unwrap_or("");
       query
@@ -937,7 +1017,9 @@ fn extract_http_message_component<B>(
 ) -> HyperSigResult<HttpMessageComponent> {
   match &target_component_id.name {
     HttpMessageComponentName::HttpField(_) => extract_http_field(req_or_res, target_component_id),
-    HttpMessageComponentName::Derived(_) => extract_derived_component(req_or_res, target_component_id),
+    HttpMessageComponentName::Derived(_) => {
+      extract_derived_component(req_or_res, target_component_id)
+    }
   }
 }
 

--- a/httpsig-hyper/src/hyper_http_tests.rs
+++ b/httpsig-hyper/src/hyper_http_tests.rs
@@ -21,7 +21,13 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
 "##;
 // const EDDSA_KEY_ID: &str = "gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=";
 const COVERED_COMPONENTS_REQ: &[&str] = &["@method", "date", "content-type", "content-digest"];
-const COVERED_COMPONENTS_RES: &[&str] = &["@status", "\"@method\";req", "date", "content-type", "\"content-digest\";req"];
+const COVERED_COMPONENTS_RES: &[&str] = &[
+  "@status",
+  "\"@method\";req",
+  "date",
+  "content-type",
+  "\"content-digest\";req",
+];
 
 async fn build_request() -> Request<BoxBody> {
   let body = Full::new(&b"{\"hello\": \"world\"}"[..]);
@@ -33,7 +39,10 @@ async fn build_request() -> Request<BoxBody> {
     .header("content-type", "application/json-patch+json")
     .body(body)
     .unwrap();
-  req.set_content_digest(&ContentDigestType::Sha256).await.unwrap()
+  req
+    .set_content_digest(&ContentDigestType::Sha256)
+    .await
+    .unwrap()
 }
 
 async fn build_response() -> Response<BoxBody> {
@@ -45,7 +54,10 @@ async fn build_response() -> Response<BoxBody> {
     .header("content-type", "application/json-patch+json")
     .body(body)
     .unwrap();
-  res.set_content_digest(&ContentDigestType::Sha256).await.unwrap()
+  res
+    .set_content_digest(&ContentDigestType::Sha256)
+    .await
+    .unwrap()
 }
 
 fn build_covered_components_req() -> Vec<HttpMessageComponentId> {
@@ -64,7 +76,9 @@ fn build_covered_components_res() -> Vec<HttpMessageComponentId> {
 
 /// Helper to build a request with query parameters (no content-digest needed)
 fn build_query_request() -> Request<BoxBody> {
-  let body = Full::new(bytes::Bytes::new()).map_err(|never| match never {}).boxed();
+  let body = Full::new(bytes::Bytes::new())
+    .map_err(|never| match never {})
+    .boxed();
   Request::builder()
     .method("GET")
     .uri("https://example.com/path?foo=bar&id=123&x=y")
@@ -86,7 +100,10 @@ async fn test_extract_component_from_request() {
 
   let component_id = HttpMessageComponentId::try_from("\"date\"").unwrap();
   let component = extract_http_message_component(&req_or_res, &component_id).unwrap();
-  assert_eq!(component.to_string(), "\"date\": Sun, 09 May 2021 18:30:00 GMT");
+  assert_eq!(
+    component.to_string(),
+    "\"date\": Sun, 09 May 2021 18:30:00 GMT"
+  );
 
   let component_id = HttpMessageComponentId::try_from("content-type").unwrap();
   let component = extract_http_field(&req_or_res, &component_id).unwrap();
@@ -114,10 +131,19 @@ async fn test_extract_signature_params_from_request() {
   let component_id = HttpMessageComponentId::try_from("@signature-params").unwrap();
   let req_or_res = RequestOrResponse::Request(&req);
   let component = extract_http_message_component(&req_or_res, &component_id).unwrap();
-  assert_eq!(component.to_string(), "\"@signature-params\": (\"@method\" \"@authority\")");
+  assert_eq!(
+    component.to_string(),
+    "\"@signature-params\": (\"@method\" \"@authority\")"
+  );
   assert_eq!(component.value.to_string(), r##"("@method" "@authority")"##);
-  assert_eq!(component.value.as_field_value(), r##"sig1=("@method" "@authority")"##);
-  assert_eq!(component.value.as_component_value(), r##"("@method" "@authority")"##);
+  assert_eq!(
+    component.value.as_field_value(),
+    r##"sig1=("@method" "@authority")"##
+  );
+  assert_eq!(
+    component.value.as_component_value(),
+    r##"("@method" "@authority")"##
+  );
   assert_eq!(component.value.key(), Some("sig1"));
 }
 
@@ -125,12 +151,18 @@ async fn test_extract_signature_params_from_request() {
 async fn test_build_signature_base_from_request() {
   let req = build_request().await;
 
-  const SIGPARA: &str = r##";created=1704972031;alg="ed25519";keyid="gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=""##;
-  let values = (r##""@method" "content-type" "date" "content-digest""##, SIGPARA);
-  let signature_params = HttpSignatureParams::try_from(format!("({}){}", values.0, values.1).as_str()).unwrap();
+  const SIGPARA: &str =
+    r##";created=1704972031;alg="ed25519";keyid="gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=""##;
+  let values = (
+    r##""@method" "content-type" "date" "content-digest""##,
+    SIGPARA,
+  );
+  let signature_params =
+    HttpSignatureParams::try_from(format!("({}){}", values.0, values.1).as_str()).unwrap();
 
   let req_or_res = RequestOrResponse::Request(&req);
-  let signature_base = build_signature_base(&req_or_res, &signature_params, None as Option<&Request<()>>).unwrap();
+  let signature_base =
+    build_signature_base(&req_or_res, &signature_params, None as Option<&Request<()>>).unwrap();
   assert_eq!(
     signature_base.to_string(),
     r##""@method": GET
@@ -175,9 +207,19 @@ async fn test_set_verify_message_signature_req() {
   let mut signature_params = HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
   signature_params.set_key_info(&secret_key);
 
-  req.set_message_signature(&signature_params, &secret_key, None).await.unwrap();
-  let signature_input = req.headers().get("signature-input").unwrap().to_str().unwrap();
-  assert!(signature_input.starts_with(r##"sig=("@method" "date" "content-type" "content-digest")"##));
+  req
+    .set_message_signature(&signature_params, &secret_key, None)
+    .await
+    .unwrap();
+  let signature_input = req
+    .headers()
+    .get("signature-input")
+    .unwrap()
+    .to_str()
+    .unwrap();
+  assert!(
+    signature_input.starts_with(r##"sig=("@method" "date" "content-type" "content-digest")"##)
+  );
 
   let public_key = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
   let verification_res = req.verify_message_signature(&public_key, None).await;
@@ -198,11 +240,19 @@ async fn test_set_verify_message_signature_res() {
     .set_message_signature(&signature_params, &secret_key, None, Some(&req))
     .await
     .unwrap();
-  let signature_input = res.headers().get("signature-input").unwrap().to_str().unwrap();
-  assert!(signature_input.starts_with(r##"sig=("@status" "@method";req "date" "content-type" "content-digest";req)"##));
+  let signature_input = res
+    .headers()
+    .get("signature-input")
+    .unwrap()
+    .to_str()
+    .unwrap();
+  assert!(signature_input
+    .starts_with(r##"sig=("@status" "@method";req "date" "content-type" "content-digest";req)"##));
 
   let public_key = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
-  let verification_res = res.verify_message_signature(&public_key, None, Some(&req)).await;
+  let verification_res = res
+    .verify_message_signature(&public_key, None, Some(&req))
+    .await;
   assert!(verification_res.is_ok());
 }
 
@@ -216,7 +266,10 @@ async fn test_expired_signature() {
   signature_params.set_expires(created - 1);
   assert!(signature_params.is_expired());
 
-  req.set_message_signature(&signature_params, &secret_key, None).await.unwrap();
+  req
+    .set_message_signature(&signature_params, &secret_key, None)
+    .await
+    .unwrap();
 
   let public_key = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
   let verification_res = req.verify_message_signature(&public_key, None).await;
@@ -252,14 +305,21 @@ async fn test_set_verify_with_key_id() {
   let mut signature_params = HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
   signature_params.set_key_info(&secret_key);
 
-  req.set_message_signature(&signature_params, &secret_key, None).await.unwrap();
+  req
+    .set_message_signature(&signature_params, &secret_key, None)
+    .await
+    .unwrap();
 
   let public_key = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
   let key_id = public_key.key_id();
-  let verification_res = req.verify_message_signature(&public_key, Some(&key_id)).await;
+  let verification_res = req
+    .verify_message_signature(&public_key, Some(&key_id))
+    .await;
   assert!(verification_res.is_ok());
 
-  let verification_res = req.verify_message_signature(&public_key, Some("NotFoundKeyId")).await;
+  let verification_res = req
+    .verify_message_signature(&public_key, Some("NotFoundKeyId"))
+    .await;
   assert!(verification_res.is_err());
 }
 
@@ -269,13 +329,17 @@ const HMACSHA256_SECRET_KEY: &str =
 #[tokio::test]
 async fn test_set_verify_with_key_id_hmac_sha256() {
   let mut req = build_request().await;
-  let secret_key = SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
+  let secret_key =
+    SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
   let mut signature_params = HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
   signature_params.set_key_info(&secret_key);
   // Random nonce is highly recommended for HMAC
   signature_params.set_random_nonce();
 
-  req.set_message_signature(&signature_params, &secret_key, None).await.unwrap();
+  req
+    .set_message_signature(&signature_params, &secret_key, None)
+    .await
+    .unwrap();
 
   let org_key_id = VerifyingKey::key_id(&secret_key);
   let (alg, key_id) = req.get_alg_key_ids().unwrap().into_iter().next().unwrap().1;
@@ -283,10 +347,14 @@ async fn test_set_verify_with_key_id_hmac_sha256() {
   let key_id = key_id.unwrap();
   assert_eq!(org_key_id, key_id);
   let verification_key = SharedKey::from_base64(&alg, HMACSHA256_SECRET_KEY).unwrap();
-  let verification_res = req.verify_message_signature(&verification_key, Some(&key_id)).await;
+  let verification_res = req
+    .verify_message_signature(&verification_key, Some(&key_id))
+    .await;
   assert!(verification_res.is_ok());
 
-  let verification_res = req.verify_message_signature(&verification_key, Some("NotFoundKeyId")).await;
+  let verification_res = req
+    .verify_message_signature(&verification_key, Some("NotFoundKeyId"))
+    .await;
   assert!(verification_res.is_err());
 }
 
@@ -297,11 +365,17 @@ async fn test_get_alg_key_ids() {
   let mut signature_params = HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
   signature_params.set_key_info(&secret_key);
 
-  req.set_message_signature(&signature_params, &secret_key, None).await.unwrap();
+  req
+    .set_message_signature(&signature_params, &secret_key, None)
+    .await
+    .unwrap();
   let key_ids = req.get_alg_key_ids().unwrap();
   assert_eq!(key_ids.len(), 1);
   assert_eq!(key_ids[0].0.as_ref().unwrap(), &AlgorithmName::Ed25519);
-  assert_eq!(key_ids[0].1.as_ref().unwrap(), "gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=");
+  assert_eq!(
+    key_ids[0].1.as_ref().unwrap(),
+    "gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is="
+  );
 }
 
 const P256_SECRET_KEY: &str = r##"-----BEGIN PRIVATE KEY-----
@@ -320,22 +394,30 @@ async fn test_set_verify_multiple_signatures() {
   let mut req = build_request().await;
 
   let secret_key_eddsa = SecretKey::from_pem(&AlgorithmName::Ed25519, EDDSA_SECRET_KEY).unwrap();
-  let mut signature_params_eddsa = HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
+  let mut signature_params_eddsa =
+    HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
   signature_params_eddsa.set_key_info(&secret_key_eddsa);
 
-  let secret_key_p256 = SecretKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_SECRET_KEY).unwrap();
-  let mut signature_params_hmac = HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
+  let secret_key_p256 =
+    SecretKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_SECRET_KEY).unwrap();
+  let mut signature_params_hmac =
+    HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
   signature_params_hmac.set_key_info(&secret_key_p256);
 
   let params_key_name = &[
-    (&signature_params_eddsa, &secret_key_eddsa, Some("eddsa_sig")),
+    (
+      &signature_params_eddsa,
+      &secret_key_eddsa,
+      Some("eddsa_sig"),
+    ),
     (&signature_params_hmac, &secret_key_p256, Some("p256_sig")),
   ];
 
   req.set_message_signatures(params_key_name).await.unwrap();
 
   let public_key_eddsa = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
-  let public_key_p256 = PublicKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_PUBLIC_KEY).unwrap();
+  let public_key_p256 =
+    PublicKey::from_pem(&AlgorithmName::EcdsaP256Sha256, P256_PUBLIC_KEY).unwrap();
   let key_id_eddsa = public_key_eddsa.key_id();
   let key_id_p256 = public_key_p256.key_id();
 
@@ -362,7 +444,9 @@ fn test_blocking_set_verify_message_signature_req() {
   let mut signature_params = HttpSignatureParams::try_new(&build_covered_components_req()).unwrap();
   signature_params.set_key_info(&secret_key);
 
-  req.set_message_signature_sync(&signature_params, &secret_key, None).unwrap();
+  req
+    .set_message_signature_sync(&signature_params, &secret_key, None)
+    .unwrap();
 
   let public_key = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
   let verification_res = req.verify_message_signature_sync(&public_key, None);
@@ -413,7 +497,10 @@ fn test_query_param_sign_verify_sync() {
     req.headers().get("signature-input").is_some(),
     "signature-input header is missing"
   );
-  assert!(req.headers().get("signature").is_some(), "signature header is missing");
+  assert!(
+    req.headers().get("signature").is_some(),
+    "signature header is missing"
+  );
 
   let public_key = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
   let verification_res = req.verify_message_signature_sync(&public_key, None);
@@ -449,7 +536,10 @@ async fn test_query_param_sign_verify_async() {
     req.headers().get("signature-input").is_some(),
     "signature-input header is missing"
   );
-  assert!(req.headers().get("signature").is_some(), "signature header is missing");
+  assert!(
+    req.headers().get("signature").is_some(),
+    "signature header is missing"
+  );
 
   let public_key = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
   let verification_res = req.verify_message_signature(&public_key, None).await;
@@ -483,7 +573,10 @@ fn test_extract_derived_component_rejects_sf_on_derived() {
   let id = HttpMessageComponentId::try_from("\"@method\";sf");
   if let Ok(id) = id {
     let result = extract_derived_component(&req_or_res, &id);
-    assert!(result.is_err(), "expected error for `sf` on derived component");
+    assert!(
+      result.is_err(),
+      "expected error for `sf` on derived component"
+    );
   }
 }
 
@@ -492,7 +585,9 @@ fn test_extract_derived_component_rejects_sf_on_derived() {
 #[tokio::test]
 async fn test_set_message_signature_propagates_build_error() {
   // Use `@status` on a request — this is invalid and must return Err, not Ok
-  let body = Full::new(bytes::Bytes::new()).map_err(|never| match never {}).boxed();
+  let body = Full::new(bytes::Bytes::new())
+    .map_err(|never| match never {})
+    .boxed();
   let mut req: Request<BoxBody> = Request::builder()
     .method("GET")
     .uri("https://example.com/")
@@ -507,14 +602,19 @@ async fn test_set_message_signature_propagates_build_error() {
   let result = req
     .set_message_signature(&signature_params, &secret_key, None as Option<&str>)
     .await;
-  assert!(result.is_err(), "expected Err when using `@status` on request, got Ok");
+  assert!(
+    result.is_err(),
+    "expected Err when using `@status` on request, got Ok"
+  );
 }
 
 #[cfg(feature = "blocking")]
 #[test]
 fn test_set_message_signature_sync_propagates_build_error() {
   // Same as above but for sync path
-  let body = Full::new(bytes::Bytes::new()).map_err(|never| match never {}).boxed();
+  let body = Full::new(bytes::Bytes::new())
+    .map_err(|never| match never {})
+    .boxed();
   let mut req: Request<BoxBody> = Request::builder()
     .method("GET")
     .uri("https://example.com/")
@@ -527,7 +627,10 @@ fn test_set_message_signature_sync_propagates_build_error() {
   signature_params.set_key_info(&secret_key);
 
   let result = req.set_message_signature_sync(&signature_params, &secret_key, None);
-  assert!(result.is_err(), "expected Err when using `@status` on request, got Ok");
+  assert!(
+    result.is_err(),
+    "expected Err when using `@status` on request, got Ok"
+  );
 }
 
 // ---- RFC 9421 §2.2: Derived component extraction values ----
@@ -546,7 +649,10 @@ fn test_extract_derived_components_values() {
   // @target-uri (§2.2.2)
   let id = HttpMessageComponentId::try_from("@target-uri").unwrap();
   let c = extract_derived_component(&req_or_res, &id).unwrap();
-  assert_eq!(c.to_string(), "\"@target-uri\": https://example.com/path?foo=bar&id=123&x=y");
+  assert_eq!(
+    c.to_string(),
+    "\"@target-uri\": https://example.com/path?foo=bar&id=123&x=y"
+  );
 
   // @authority (§2.2.3)
   let id = HttpMessageComponentId::try_from("@authority").unwrap();
@@ -581,7 +687,9 @@ async fn test_response_with_query_param_req_sign_verify() {
   // Build a request with query params
   let req = build_query_request();
   // Build a response
-  let body = Full::new(bytes::Bytes::new()).map_err(|never| match never {}).boxed();
+  let body = Full::new(bytes::Bytes::new())
+    .map_err(|never| match never {})
+    .boxed();
   let mut res: Response<BoxBody> = Response::builder().status(200).body(body).unwrap();
 
   // Response signature covering @status + @query-param;name="id";req
@@ -601,20 +709,37 @@ async fn test_response_with_query_param_req_sign_verify() {
     .await
     .unwrap();
 
-  assert!(req.headers().get("signature-input").is_none(), "request should not be modified");
-  assert!(res.headers().get("signature-input").is_some(), "signature-input header is missing on response");
-  assert!(res.headers().get("signature").is_some(), "signature header is missing on response");
+  assert!(
+    req.headers().get("signature-input").is_none(),
+    "request should not be modified"
+  );
+  assert!(
+    res.headers().get("signature-input").is_some(),
+    "signature-input header is missing on response"
+  );
+  assert!(
+    res.headers().get("signature").is_some(),
+    "signature header is missing on response"
+  );
 
   let public_key = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
-  let verification_res = res.verify_message_signature(&public_key, None, Some(&req)).await;
-  assert!(verification_res.is_ok(), "signature verification failed: {:?}", verification_res.err());
+  let verification_res = res
+    .verify_message_signature(&public_key, None, Some(&req))
+    .await;
+  assert!(
+    verification_res.is_ok(),
+    "signature verification failed: {:?}",
+    verification_res.err()
+  );
 }
 
 // ---- RFC 9421: Response must reject request-derived components without `req` ----
 
 #[tokio::test]
 async fn test_response_rejects_derived_component_without_req() {
-  let body = Full::new(bytes::Bytes::new()).map_err(|never| match never {}).boxed();
+  let body = Full::new(bytes::Bytes::new())
+    .map_err(|never| match never {})
+    .boxed();
   let mut res: Response<BoxBody> = Response::builder().status(200).body(body).unwrap();
 
   // `@method` without `req` on a response — must fail
@@ -628,7 +753,15 @@ async fn test_response_rejects_derived_component_without_req() {
   signature_params.set_key_info(&secret_key);
 
   let result = res
-    .set_message_signature(&signature_params, &secret_key, None, None as Option<&Request<()>>)
+    .set_message_signature(
+      &signature_params,
+      &secret_key,
+      None,
+      None as Option<&Request<()>>,
+    )
     .await;
-  assert!(result.is_err(), "expected Err when using `@method` without `req` on response");
+  assert!(
+    result.is_err(),
+    "expected Err when using `@method` without `req` on response"
+  );
 }

--- a/httpsig-hyper/src/lib.rs
+++ b/httpsig-hyper/src/lib.rs
@@ -50,7 +50,9 @@ impl std::str::FromStr for ContentDigestType {
     match s {
       "sha-256" => Ok(ContentDigestType::Sha256),
       "sha-512" => Ok(ContentDigestType::Sha512),
-      _ => Err(error::HyperDigestError::InvalidContentDigestType(s.to_string())),
+      _ => Err(error::HyperDigestError::InvalidContentDigestType(
+        s.to_string(),
+      )),
     }
   }
 }
@@ -83,7 +85,13 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
   // const EDDSA_KEY_ID: &str = "gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is";
 
   const COVERED_COMPONENTS_REQ: &[&str] = &["@method", "date", "content-type", "content-digest"];
-  const COVERED_COMPONENTS_RES: &[&str] = &["@status", "\"@method\";req", "date", "content-type", "\"content-digest\";req"];
+  const COVERED_COMPONENTS_RES: &[&str] = &[
+    "@status",
+    "\"@method\";req",
+    "date",
+    "content-type",
+    "\"content-digest\";req",
+  ];
 
   async fn build_request() -> Request<BoxBody> {
     let body = Full::new(&b"{\"hello\": \"world\"}"[..]);
@@ -95,7 +103,10 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
         .header("content-type", "application/json-patch+json")
         .body(body)
         .unwrap();
-    req.set_content_digest(&ContentDigestType::Sha256).await.unwrap()
+    req
+      .set_content_digest(&ContentDigestType::Sha256)
+      .await
+      .unwrap()
   }
 
   async fn build_response() -> Response<BoxBody> {
@@ -107,7 +118,10 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
       .header("content-type", "application/json-patch+json")
       .body(body)
       .unwrap();
-    res.set_content_digest(&ContentDigestType::Sha256).await.unwrap()
+    res
+      .set_content_digest(&ContentDigestType::Sha256)
+      .await
+      .unwrap()
   }
 
   #[test]
@@ -139,7 +153,12 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
       .set_message_signature(&signature_params, &secret_key, Some("custom_sig_name"))
       .await
       .unwrap();
-    let signature_input = req.headers().get("signature-input").unwrap().to_str().unwrap();
+    let signature_input = req
+      .headers()
+      .get("signature-input")
+      .unwrap()
+      .to_str()
+      .unwrap();
     let signature = req.headers().get("signature").unwrap().to_str().unwrap();
     assert!(signature_input.starts_with(r##"custom_sig_name=("##));
     assert!(signature.starts_with(r##"custom_sig_name=:"##));
@@ -153,10 +172,14 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
 
     // verify with checking key_id
     let key_id = public_key.key_id();
-    let verification_res = req.verify_message_signature(&public_key, Some(&key_id)).await;
+    let verification_res = req
+      .verify_message_signature(&public_key, Some(&key_id))
+      .await;
     assert!(verification_res.is_ok());
 
-    let verification_res = req.verify_message_signature(&public_key, Some("NotFoundKeyId")).await;
+    let verification_res = req
+      .verify_message_signature(&public_key, Some("NotFoundKeyId"))
+      .await;
     assert!(verification_res.is_err());
   }
 
@@ -181,10 +204,20 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
 
     // set custom signature name, and `req` field param if needed (e.g., request method, uri, content-digest, etc.) included only in response
     res
-      .set_message_signature(&signature_params, &secret_key, Some("custom_sig_name"), Some(&req))
+      .set_message_signature(
+        &signature_params,
+        &secret_key,
+        Some("custom_sig_name"),
+        Some(&req),
+      )
       .await
       .unwrap();
-    let signature_input = res.headers().get("signature-input").unwrap().to_str().unwrap();
+    let signature_input = res
+      .headers()
+      .get("signature-input")
+      .unwrap()
+      .to_str()
+      .unwrap();
     let signature = res.headers().get("signature").unwrap().to_str().unwrap();
     assert!(signature_input.starts_with(r##"custom_sig_name=("##));
     assert!(signature.starts_with(r##"custom_sig_name=:"##));
@@ -193,7 +226,9 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
     // get algorithm from signature params
     let (alg, _key_id) = res.get_alg_key_ids().unwrap().into_iter().next().unwrap().1;
     let public_key = PublicKey::from_pem(&alg.unwrap(), EDDSA_PUBLIC_KEY).unwrap();
-    let verification_res = res.verify_message_signature(&public_key, None, Some(&req)).await;
+    let verification_res = res
+      .verify_message_signature(&public_key, None, Some(&req))
+      .await;
     assert!(verification_res.is_ok());
     let verification_res = res
       .verify_message_signature(&public_key, None, None as Option<&Request<()>>)
@@ -202,7 +237,9 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
 
     // verify with checking key_id
     let key_id = public_key.key_id();
-    let verification_res = res.verify_message_signature(&public_key, Some(&key_id), Some(&req)).await;
+    let verification_res = res
+      .verify_message_signature(&public_key, Some(&key_id), Some(&req))
+      .await;
     assert!(verification_res.is_ok());
 
     let verification_res = res
@@ -227,7 +264,9 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
     // set key information, alg and keyid
     signature_params.set_key_info(&secret_key);
     // set signature
-    req.set_message_signature_sync(&signature_params, &secret_key, None).unwrap();
+    req
+      .set_message_signature_sync(&signature_params, &secret_key, None)
+      .unwrap();
 
     let (alg, _key_id) = req.get_alg_key_ids().unwrap().into_iter().next().unwrap().1;
     let public_key = PublicKey::from_pem(&alg.unwrap(), EDDSA_PUBLIC_KEY).unwrap();

--- a/httpsig-hyper/src/lib.rs
+++ b/httpsig-hyper/src/lib.rs
@@ -61,7 +61,8 @@ pub use error::{HyperDigestError, HyperDigestResult, HyperSigError, HyperSigResu
 pub use httpsig::prelude;
 pub use hyper_content_digest::{ContentDigest, RequestContentDigest, ResponseContentDigest};
 pub use hyper_http::{
-  MessageSignature, MessageSignatureReq, MessageSignatureReqSync, MessageSignatureRes, MessageSignatureResSync,
+  MessageSignature, MessageSignatureReq, MessageSignatureReqSync, MessageSignatureRes,
+  MessageSignatureResSync,
 };
 
 /* ----------------------------------------------------------------- */

--- a/httpsig/src/crypto/asymmetric.rs
+++ b/httpsig/src/crypto/asymmetric.rs
@@ -66,12 +66,14 @@ impl SecretKey {
     match alg {
       AlgorithmName::EcdsaP256Sha256 => {
         debug!("Read P256 private key");
-        let sk = EcSecretKey::from_bytes(bytes.into()).map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
+        let sk = EcSecretKey::from_bytes(bytes.into())
+          .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
         Ok(Self::EcdsaP256Sha256(sk))
       }
       AlgorithmName::EcdsaP384Sha384 => {
         debug!("Read P384 private key");
-        let sk = EcSecretKey::from_bytes(bytes.into()).map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
+        let sk = EcSecretKey::from_bytes(bytes.into())
+          .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
         Ok(Self::EcdsaP384Sha384(sk))
       }
       AlgorithmName::Ed25519 => {
@@ -85,23 +87,32 @@ impl SecretKey {
       AlgorithmName::RsaV1_5Sha256 => {
         debug!("Read RSA private key");
         // read PrivateKeyInfo.private_key as RsaPrivateKey (RFC 3447), which is DER encoded RSAPrivateKey in PKCS#1
-        let sk = RsaPrivateKey::from_pkcs1_der(bytes).map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
-        Ok(Self::RsaV1_5Sha256(pkcs1v15::SigningKey::<rsa::sha2::Sha256>::new(sk)))
+        let sk = RsaPrivateKey::from_pkcs1_der(bytes)
+          .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
+        Ok(Self::RsaV1_5Sha256(
+          pkcs1v15::SigningKey::<rsa::sha2::Sha256>::new(sk),
+        ))
       }
       #[cfg(feature = "rsa-signature")]
       AlgorithmName::RsaPssSha512 => {
         debug!("Read RSA-PSS private key");
         // read PrivateKeyInfo.private_key as RsaPrivateKey (RFC 3447), which is DER encoded RSAPrivateKey in PKCS#1
-        let sk = RsaPrivateKey::from_pkcs1_der(bytes).map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
-        Ok(Self::RsaPssSha512(pss::SigningKey::<rsa::sha2::Sha512>::new(sk)))
+        let sk = RsaPrivateKey::from_pkcs1_der(bytes)
+          .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
+        Ok(Self::RsaPssSha512(
+          pss::SigningKey::<rsa::sha2::Sha512>::new(sk),
+        ))
       }
-      _ => Err(HttpSigError::ParsePrivateKeyError("Unsupported algorithm".to_string())),
+      _ => Err(HttpSigError::ParsePrivateKeyError(
+        "Unsupported algorithm".to_string(),
+      )),
     }
   }
   /// parse der
   /// Derive secret key from der bytes
   pub fn from_der(alg: &AlgorithmName, der: &[u8]) -> HttpSigResult<Self> {
-    let pki = PrivateKeyInfo::from_der(der).map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
+    let pki = PrivateKeyInfo::from_der(der)
+      .map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
 
     let sk_bytes = match pki.algorithm.oid.to_string().as_ref() {
       // ec
@@ -113,14 +124,22 @@ impl SecretKey {
         let algorithm_name = match param.to_string().as_ref() {
           params_oids::Secp256r1 => AlgorithmName::EcdsaP256Sha256,
           params_oids::Secp384r1 => AlgorithmName::EcdsaP384Sha384,
-          _ => return Err(HttpSigError::ParsePrivateKeyError("Unsupported curve".to_string())),
+          _ => {
+            return Err(HttpSigError::ParsePrivateKeyError(
+              "Unsupported curve".to_string(),
+            ))
+          }
         };
         // assert algorithm
         if algorithm_name != *alg {
-          return Err(HttpSigError::ParsePrivateKeyError("Algorithm mismatch".to_string()));
+          return Err(HttpSigError::ParsePrivateKeyError(
+            "Algorithm mismatch".to_string(),
+          ));
         }
         let sk_bytes = sec1::EcPrivateKey::try_from(pki.private_key)
-          .map_err(|e| HttpSigError::ParsePrivateKeyError(format!("Error decoding EcPrivateKey: {e}")))?
+          .map_err(|e| {
+            HttpSigError::ParsePrivateKeyError(format!("Error decoding EcPrivateKey: {e}"))
+          })?
           .private_key;
         sk_bytes
       }
@@ -128,7 +147,9 @@ impl SecretKey {
       algorithm_oids::Ed25519 => {
         // assert algorithm
         if AlgorithmName::Ed25519 != *alg {
-          return Err(HttpSigError::ParsePrivateKeyError("Algorithm mismatch".to_string()));
+          return Err(HttpSigError::ParsePrivateKeyError(
+            "Algorithm mismatch".to_string(),
+          ));
         }
         &pki.private_key[2..]
       }
@@ -138,11 +159,19 @@ impl SecretKey {
         // assert algorithm
         match alg {
           AlgorithmName::RsaV1_5Sha256 | AlgorithmName::RsaPssSha512 => {}
-          _ => return Err(HttpSigError::ParsePrivateKeyError("Algorithm mismatch".to_string())),
+          _ => {
+            return Err(HttpSigError::ParsePrivateKeyError(
+              "Algorithm mismatch".to_string(),
+            ))
+          }
         }
         pki.private_key
       }
-      _ => return Err(HttpSigError::ParsePrivateKeyError("Unsupported algorithm".to_string())),
+      _ => {
+        return Err(HttpSigError::ParsePrivateKeyError(
+          "Unsupported algorithm".to_string(),
+        ))
+      }
     };
     let sk = Self::from_bytes(alg, sk_bytes)?;
     Ok(sk)
@@ -150,9 +179,12 @@ impl SecretKey {
 
   /// Derive secret key from pem string
   pub fn from_pem(alg: &AlgorithmName, pem: &str) -> HttpSigResult<Self> {
-    let (tag, doc) = Document::from_pem(pem).map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
+    let (tag, doc) =
+      Document::from_pem(pem).map_err(|e| HttpSigError::ParsePrivateKeyError(e.to_string()))?;
     if tag != "PRIVATE KEY" {
-      return Err(HttpSigError::ParsePrivateKeyError("Invalid tag".to_string()));
+      return Err(HttpSigError::ParsePrivateKeyError(
+        "Invalid tag".to_string(),
+      ));
     };
     Self::from_der(alg, doc.as_bytes())
   }
@@ -261,47 +293,58 @@ impl PublicKey {
     match alg {
       AlgorithmName::EcdsaP256Sha256 => {
         debug!("Read P256 public key");
-        let pk = EcPublicKey::from_sec1_bytes(bytes).map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
+        let pk = EcPublicKey::from_sec1_bytes(bytes)
+          .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
         Ok(Self::EcdsaP256Sha256(pk))
       }
       AlgorithmName::EcdsaP384Sha384 => {
         debug!("Read P384 public key");
-        let pk = EcPublicKey::from_sec1_bytes(bytes).map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
+        let pk = EcPublicKey::from_sec1_bytes(bytes)
+          .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
         Ok(Self::EcdsaP384Sha384(pk))
       }
       AlgorithmName::Ed25519 => {
         debug!("Read Ed25519 public key");
-        let pk = ed25519_compact::PublicKey::from_slice(bytes).map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
+        let pk = ed25519_compact::PublicKey::from_slice(bytes)
+          .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
         Ok(Self::Ed25519(pk))
       }
       #[cfg(feature = "rsa-signature")]
       AlgorithmName::RsaV1_5Sha256 => {
         debug!("Read RSA public key");
         // read RsaPublicKey in PKCS#1 DER format
-        let pk = RsaPublicKey::from_pkcs1_der(bytes).map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
+        let pk = RsaPublicKey::from_pkcs1_der(bytes)
+          .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
         Ok(Self::RsaV1_5Sha256(pkcs1v15::VerifyingKey::new(pk)))
       }
       #[cfg(feature = "rsa-signature")]
       AlgorithmName::RsaPssSha512 => {
         debug!("Read RSA-PSS public key");
         // read RsaPublicKey in PKCS#1 DER format
-        let pk = RsaPublicKey::from_pkcs1_der(bytes).map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
+        let pk = RsaPublicKey::from_pkcs1_der(bytes)
+          .map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
         Ok(Self::RsaPssSha512(pss::VerifyingKey::new(pk)))
       }
-      _ => Err(HttpSigError::ParsePublicKeyError("Unsupported algorithm".to_string())),
+      _ => Err(HttpSigError::ParsePublicKeyError(
+        "Unsupported algorithm".to_string(),
+      )),
     }
   }
 
   #[allow(dead_code)]
   /// Convert from pem string
   pub fn from_pem(alg: &AlgorithmName, pem: &str) -> HttpSigResult<Self> {
-    let (tag, doc) = Document::from_pem(pem).map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
+    let (tag, doc) =
+      Document::from_pem(pem).map_err(|e| HttpSigError::ParsePublicKeyError(e.to_string()))?;
     if tag != "PUBLIC KEY" {
       return Err(HttpSigError::ParsePublicKeyError("Invalid tag".to_string()));
     };
 
-    let spki_ref = SubjectPublicKeyInfoRef::from_der(doc.as_bytes())
-      .map_err(|e| HttpSigError::ParsePublicKeyError(format!("Error decoding SubjectPublicKeyInfo: {e}").to_string()))?;
+    let spki_ref = SubjectPublicKeyInfoRef::from_der(doc.as_bytes()).map_err(|e| {
+      HttpSigError::ParsePublicKeyError(
+        format!("Error decoding SubjectPublicKeyInfo: {e}").to_string(),
+      )
+    })?;
 
     let pk_bytes = match spki_ref.algorithm.oid.to_string().as_ref() {
       // ec
@@ -313,41 +356,63 @@ impl PublicKey {
         let algorithm_name = match param.to_string().as_ref() {
           params_oids::Secp256r1 => AlgorithmName::EcdsaP256Sha256,
           params_oids::Secp384r1 => AlgorithmName::EcdsaP384Sha384,
-          _ => return Err(HttpSigError::ParsePublicKeyError("Unsupported curve".to_string())),
+          _ => {
+            return Err(HttpSigError::ParsePublicKeyError(
+              "Unsupported curve".to_string(),
+            ))
+          }
         };
         // assert algorithm
         if algorithm_name != *alg {
-          return Err(HttpSigError::ParsePublicKeyError("Algorithm mismatch".to_string()));
+          return Err(HttpSigError::ParsePublicKeyError(
+            "Algorithm mismatch".to_string(),
+          ));
         }
         spki_ref
           .subject_public_key
           .as_bytes()
-          .ok_or(HttpSigError::ParsePublicKeyError("Invalid public key".to_string()))?
+          .ok_or(HttpSigError::ParsePublicKeyError(
+            "Invalid public key".to_string(),
+          ))?
       }
       // ed25519
       algorithm_oids::Ed25519 => {
         // assert algorithm
         if AlgorithmName::Ed25519 != *alg {
-          return Err(HttpSigError::ParsePublicKeyError("Algorithm mismatch".to_string()));
+          return Err(HttpSigError::ParsePublicKeyError(
+            "Algorithm mismatch".to_string(),
+          ));
         }
         spki_ref
           .subject_public_key
           .as_bytes()
-          .ok_or(HttpSigError::ParsePublicKeyError("Invalid public key".to_string()))?
+          .ok_or(HttpSigError::ParsePublicKeyError(
+            "Invalid public key".to_string(),
+          ))?
       }
       // rsa
       #[cfg(feature = "rsa-signature")]
       algorithm_oids::rsaEncryption => {
         match alg {
           AlgorithmName::RsaV1_5Sha256 | AlgorithmName::RsaPssSha512 => {}
-          _ => return Err(HttpSigError::ParsePublicKeyError("Algorithm mismatch".to_string())),
+          _ => {
+            return Err(HttpSigError::ParsePublicKeyError(
+              "Algorithm mismatch".to_string(),
+            ))
+          }
         }
         spki_ref
           .subject_public_key
           .as_bytes()
-          .ok_or(HttpSigError::ParsePublicKeyError("Invalid public key".to_string()))?
+          .ok_or(HttpSigError::ParsePublicKeyError(
+            "Invalid public key".to_string(),
+          ))?
       }
-      _ => return Err(HttpSigError::ParsePublicKeyError("Unsupported algorithm".to_string())),
+      _ => {
+        return Err(HttpSigError::ParsePublicKeyError(
+          "Unsupported algorithm".to_string(),
+        ))
+      }
     };
     Self::from_bytes(alg, pk_bytes)
   }
@@ -379,22 +444,24 @@ impl super::VerifyingKey for PublicKey {
       }
       Self::Ed25519(pk) => {
         debug!("Verify Ed25519");
-        let sig =
-          ed25519_compact::Signature::from_slice(signature).map_err(|e| HttpSigError::ParseSignatureError(e.to_string()))?;
+        let sig = ed25519_compact::Signature::from_slice(signature)
+          .map_err(|e| HttpSigError::ParseSignatureError(e.to_string()))?;
         pk.verify(data, &sig)
           .map_err(|e| HttpSigError::InvalidSignature(e.to_string()))
       }
       #[cfg(feature = "rsa-signature")]
       Self::RsaV1_5Sha256(pk) => {
         debug!("Verify RsaV1_5Sha256");
-        let sig = pkcs1v15::Signature::try_from(signature).map_err(|e| HttpSigError::ParseSignatureError(e.to_string()))?;
+        let sig = pkcs1v15::Signature::try_from(signature)
+          .map_err(|e| HttpSigError::ParseSignatureError(e.to_string()))?;
         pk.verify(data, &sig)
           .map_err(|e| HttpSigError::InvalidSignature(e.to_string()))
       }
       #[cfg(feature = "rsa-signature")]
       Self::RsaPssSha512(pk) => {
         debug!("Verify RsaPssSha512");
-        let sig = pss::Signature::try_from(signature).map_err(|e| HttpSigError::ParseSignatureError(e.to_string()))?;
+        let sig = pss::Signature::try_from(signature)
+          .map_err(|e| HttpSigError::ParseSignatureError(e.to_string()))?;
         pk.verify(data, &sig)
           .map_err(|e| HttpSigError::InvalidSignature(e.to_string()))
       }
@@ -540,7 +607,11 @@ tQIDAQAB
     let mut rng = rand_085::thread_rng();
     let es256_sk = p256::ecdsa::SigningKey::random(&mut rng);
     let es256_pk = es256_sk.verifying_key();
-    let sk = SecretKey::from_bytes(&AlgorithmName::EcdsaP256Sha256, es256_sk.to_bytes().as_ref()).unwrap();
+    let sk = SecretKey::from_bytes(
+      &AlgorithmName::EcdsaP256Sha256,
+      es256_sk.to_bytes().as_ref(),
+    )
+    .unwrap();
     assert!(matches!(sk, SecretKey::EcdsaP256Sha256(_)));
     let pk_bytes = es256_pk.as_affine().to_bytes();
     let pk = PublicKey::from_bytes(&AlgorithmName::EcdsaP256Sha256, pk_bytes.as_ref()).unwrap();

--- a/httpsig/src/lib.rs
+++ b/httpsig/src/lib.rs
@@ -16,14 +16,17 @@ mod util;
 pub mod prelude {
   pub mod message_component {
     pub use crate::message_component::{
-      DerivedComponentName, HttpMessageComponent, HttpMessageComponentId, HttpMessageComponentName, HttpMessageComponentParam,
+      DerivedComponentName, HttpMessageComponent, HttpMessageComponentId, HttpMessageComponentName,
+      HttpMessageComponentParam,
     };
   }
 
   pub use crate::{
     crypto::{AlgorithmName, PublicKey, SecretKey, SharedKey, SigningKey, VerifyingKey},
     error::{HttpSigError, HttpSigResult},
-    signature_base::{HttpSignature, HttpSignatureBase, HttpSignatureHeaders, HttpSignatureHeadersMap},
+    signature_base::{
+      HttpSignature, HttpSignatureBase, HttpSignatureHeaders, HttpSignatureHeadersMap,
+    },
     signature_params::HttpSignatureParams,
   };
 }
@@ -51,7 +54,8 @@ MCowBQYDK2VwAyEAJrQLj5P/89iXES9+vFgrIy29clF9CC/oPPsw3c5D0bs=
 "content-type": application/json
 "content-length": 18
 "@signature-params": ("date" "@method" "@path" "@authority" "content-type" "content-length");created=1618884473;keyid="test-key-ed25519""##;
-  const EDDSA_SIGNATURE_VALUE: &str = "wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgwUPiu4A0w6vuQv5lIp5WPpBKRCw==";
+  const EDDSA_SIGNATURE_VALUE: &str =
+    "wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgwUPiu4A0w6vuQv5lIp5WPpBKRCw==";
   const _EDDSA_SIGNATURE_RESULT: &str = r##"Signature-Input: sig-b26=("date" "@method" "@path" "@authority" "content-type" "content-length");created=1618884473;keyid="test-key-ed25519"
 Signature: sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgwUPiu4A0w6vuQv5lIp5WPpBKRCw==:"##;
 
@@ -62,7 +66,9 @@ Signature: sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgw
     assert_eq!(pk.key_id(), sk.public_key().key_id());
 
     let data = EDDSA_SIGNATURE_BASE.as_bytes();
-    let binary_signature = general_purpose::STANDARD.decode(EDDSA_SIGNATURE_VALUE).unwrap();
+    let binary_signature = general_purpose::STANDARD
+      .decode(EDDSA_SIGNATURE_VALUE)
+      .unwrap();
     let verification_result = pk.verify(data, &binary_signature);
     assert!(verification_result.is_ok());
 
@@ -89,7 +95,9 @@ Signature: sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgw
     let sk = SharedKey::from_base64(&AlgorithmName::HmacSha256, HMACSHA256_SECRET_KEY).unwrap();
 
     let data = HMACSHA256_SIGNATURE_BASE.as_bytes();
-    let binary_signature = general_purpose::STANDARD.decode(HMACSHA256_SIGNATURE_VALUE).unwrap();
+    let binary_signature = general_purpose::STANDARD
+      .decode(HMACSHA256_SIGNATURE_VALUE)
+      .unwrap();
     let verification_result = sk.verify(data, &binary_signature);
     assert!(verification_result.is_ok());
 
@@ -111,8 +119,7 @@ Signature: sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgw
     r##""content-type": application/json"##,
     r##""content-length": 18"##,
   ];
-  const SIGNATURE_PARAMS: &str =
-    r##"("date" "@method" "@path" "@authority" "content-type" "content-length");created=1618884473;keyid="test-key-ed25519""##;
+  const SIGNATURE_PARAMS: &str = r##"("date" "@method" "@path" "@authority" "content-type" "content-length");created=1618884473;keyid="test-key-ed25519""##;
 
   #[test]
   fn test_with_directly_using_crypto_api() {
@@ -142,20 +149,33 @@ Signature: sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgw
     let signature_params = HttpSignatureParams::try_from(SIGNATURE_PARAMS).unwrap();
     let signature_base = HttpSignatureBase::try_new(&component_lines, &signature_params).unwrap();
     let sk = SecretKey::from_pem(&AlgorithmName::Ed25519, EDDSA_SECRET_KEY).unwrap();
-    let signature_headers = signature_base.build_signature_headers(&sk, Some("sig-b26")).unwrap();
+    let signature_headers = signature_base
+      .build_signature_headers(&sk, Some("sig-b26"))
+      .unwrap();
     let signature_params_header_string = signature_headers.signature_input_header_value();
     let signature_header_string = signature_headers.signature_header_value();
 
-    assert_eq!(signature_params_header_string, format!("sig-b26={}", SIGNATURE_PARAMS));
-    assert!(signature_header_string.starts_with("sig-b26=:") && signature_header_string.ends_with(':'));
+    assert_eq!(
+      signature_params_header_string,
+      format!("sig-b26={}", SIGNATURE_PARAMS)
+    );
+    assert!(
+      signature_header_string.starts_with("sig-b26=:") && signature_header_string.ends_with(':')
+    );
 
     // receiver
-    let header_map = HttpSignatureHeaders::try_parse(&signature_header_string, &signature_params_header_string).unwrap();
+    let header_map =
+      HttpSignatureHeaders::try_parse(&signature_header_string, &signature_params_header_string)
+        .unwrap();
     let received_signature_headers = header_map.get("sig-b26").unwrap();
-    let received_signature_base =
-      HttpSignatureBase::try_new(&component_lines, received_signature_headers.signature_params()).unwrap();
+    let received_signature_base = HttpSignatureBase::try_new(
+      &component_lines,
+      received_signature_headers.signature_params(),
+    )
+    .unwrap();
     let pk = PublicKey::from_pem(&AlgorithmName::Ed25519, EDDSA_PUBLIC_KEY).unwrap();
-    let verification_result = received_signature_base.verify_signature_headers(&pk, received_signature_headers);
+    let verification_result =
+      received_signature_base.verify_signature_headers(&pk, received_signature_headers);
     assert!(verification_result.is_ok());
   }
 }

--- a/httpsig/src/message_component/component.rs
+++ b/httpsig/src/message_component/component.rs
@@ -49,7 +49,9 @@ impl TryFrom<(&HttpMessageComponentId, &[String])> for HttpMessageComponent {
   type Error = HttpSigError;
 
   /// Build http message component from given id and its associated field values
-  fn try_from((id, field_values): (&HttpMessageComponentId, &[String])) -> Result<Self, Self::Error> {
+  fn try_from(
+    (id, field_values): (&HttpMessageComponentId, &[String]),
+  ) -> Result<Self, Self::Error> {
     match &id.name {
       HttpMessageComponentName::HttpField(_) => build_http_field_component(id, field_values),
       HttpMessageComponentName::Derived(_) => build_derived_component(id, field_values),
@@ -82,26 +84,42 @@ pub(super) fn build_derived_component(
     ));
   }
   // ensure only `req` and `name` are allowed for derived component parameters
-  if !id
-    .params
-    .0
-    .iter()
-    .all(|p| matches!(p, HttpMessageComponentParam::Req | HttpMessageComponentParam::Name(_)))
-  {
+  if !id.params.0.iter().all(|p| {
+    matches!(
+      p,
+      HttpMessageComponentParam::Req | HttpMessageComponentParam::Name(_)
+    )
+  }) {
     return Err(HttpSigError::InvalidComponent(
       "invalid parameter for derived component".to_string(),
     ));
   }
 
   let value = match derived_id {
-    DerivedComponentName::Method => HttpMessageComponentValue::from(field_values[0].to_ascii_uppercase().as_ref()),
-    DerivedComponentName::TargetUri => HttpMessageComponentValue::from(field_values[0].to_string().as_ref()),
-    DerivedComponentName::Authority => HttpMessageComponentValue::from(field_values[0].to_ascii_lowercase().as_ref()),
-    DerivedComponentName::Scheme => HttpMessageComponentValue::from(field_values[0].to_ascii_lowercase().as_ref()),
-    DerivedComponentName::RequestTarget => HttpMessageComponentValue::from(field_values[0].to_string().as_ref()),
-    DerivedComponentName::Path => HttpMessageComponentValue::from(field_values[0].to_string().as_ref()),
-    DerivedComponentName::Query => HttpMessageComponentValue::from(field_values[0].to_string().as_ref()),
-    DerivedComponentName::Status => HttpMessageComponentValue::from(field_values[0].to_string().as_ref()),
+    DerivedComponentName::Method => {
+      HttpMessageComponentValue::from(field_values[0].to_ascii_uppercase().as_ref())
+    }
+    DerivedComponentName::TargetUri => {
+      HttpMessageComponentValue::from(field_values[0].to_string().as_ref())
+    }
+    DerivedComponentName::Authority => {
+      HttpMessageComponentValue::from(field_values[0].to_ascii_lowercase().as_ref())
+    }
+    DerivedComponentName::Scheme => {
+      HttpMessageComponentValue::from(field_values[0].to_ascii_lowercase().as_ref())
+    }
+    DerivedComponentName::RequestTarget => {
+      HttpMessageComponentValue::from(field_values[0].to_string().as_ref())
+    }
+    DerivedComponentName::Path => {
+      HttpMessageComponentValue::from(field_values[0].to_string().as_ref())
+    }
+    DerivedComponentName::Query => {
+      HttpMessageComponentValue::from(field_values[0].to_string().as_ref())
+    }
+    DerivedComponentName::Status => {
+      HttpMessageComponentValue::from(field_values[0].to_string().as_ref())
+    }
     DerivedComponentName::QueryParam => {
       let name = id.params.0.iter().find_map(|p| match p {
         HttpMessageComponentParam::Name(name) => Some(name),
@@ -134,7 +152,10 @@ pub(super) fn build_derived_component(
       HttpMessageComponentValue::from((key, value))
     }
   };
-  let component = HttpMessageComponent { id: id.clone(), value };
+  let component = HttpMessageComponent {
+    id: id.clone(),
+    value,
+  };
   Ok(component)
 }
 
@@ -157,12 +178,18 @@ pub(super) fn build_http_field_component(
         field_values = handle_params_key_into(&field_values, key)?;
       }
       HttpMessageComponentParam::Bs => {
-        return Err(HttpSigError::NotYetImplemented("`bs` is not supported yet".to_string()));
+        return Err(HttpSigError::NotYetImplemented(
+          "`bs` is not supported yet".to_string(),
+        ));
       }
       HttpMessageComponentParam::Req => {
         debug!("`req` is given for http field component");
       }
-      HttpMessageComponentParam::Tr => return Err(HttpSigError::NotYetImplemented("`tr` is not supported yet".to_string())),
+      HttpMessageComponentParam::Tr => {
+        return Err(HttpSigError::NotYetImplemented(
+          "`tr` is not supported yet".to_string(),
+        ))
+      }
       HttpMessageComponentParam::Name(_) => {
         return Err(HttpSigError::NotYetImplemented(
           "`name` is only for derived component query-params".to_string(),
@@ -192,13 +219,29 @@ mod tests {
   fn test_from_serialized_string_derived() {
     let tuples = vec![
       ("\"@method\"", "POST", DerivedComponentName::Method),
-      ("\"@target-uri\"", "https://example.com/", DerivedComponentName::TargetUri),
-      ("\"@authority\"", "example.com", DerivedComponentName::Authority),
+      (
+        "\"@target-uri\"",
+        "https://example.com/",
+        DerivedComponentName::TargetUri,
+      ),
+      (
+        "\"@authority\"",
+        "example.com",
+        DerivedComponentName::Authority,
+      ),
       ("\"@scheme\"", "https", DerivedComponentName::Scheme),
-      ("\"@request-target\"", "/path?query", DerivedComponentName::RequestTarget),
+      (
+        "\"@request-target\"",
+        "/path?query",
+        DerivedComponentName::RequestTarget,
+      ),
       ("\"@path\"", "/path", DerivedComponentName::Path),
       ("\"@query\"", "query", DerivedComponentName::Query),
-      ("\"@query-param\";name=\"key\"", "\"value\"", DerivedComponentName::QueryParam),
+      (
+        "\"@query-param\";name=\"key\"",
+        "\"value\"",
+        DerivedComponentName::QueryParam,
+      ),
       ("\"@status\"", "200", DerivedComponentName::Status),
     ];
     for (id, value, name) in tuples {
@@ -217,11 +260,19 @@ mod tests {
 
   #[test]
   fn test_from_serialized_string_derived_query_params() {
-    let (id, value, name) = ("\"@query-param\";name=\"key\"", "\"value\"", DerivedComponentName::QueryParam);
+    let (id, value, name) = (
+      "\"@query-param\";name=\"key\"",
+      "\"value\"",
+      DerivedComponentName::QueryParam,
+    );
     let comp = HttpMessageComponent::try_from(format!("{}: {}", id, value).as_ref()).unwrap();
     assert_eq!(comp.id.name, HttpMessageComponentName::Derived(name));
     assert_eq!(
-      comp.id.params.0.get(&HttpMessageComponentParam::Name("key".to_string())),
+      comp
+        .id
+        .params
+        .0
+        .get(&HttpMessageComponentParam::Name("key".to_string())),
       Some(&HttpMessageComponentParam::Name("key".to_string()))
     );
     assert_eq!(comp.value.as_field_value(), value);
@@ -233,13 +284,20 @@ mod tests {
   fn test_from_serialized_string_http_field() {
     let tuples = vec![
       ("\"example-header\"", "example-value", "example-header"),
-      ("\"example-header\";bs;tr", "example-value", "example-header"),
+      (
+        "\"example-header\";bs;tr",
+        "example-value",
+        "example-header",
+      ),
       ("\"example-header\";bs", "example-value", "example-header"),
       ("\"x-empty-header\"", "", "x-empty-header"),
     ];
     for (id, value, inner_name) in tuples {
       let comp = HttpMessageComponent::try_from(format!("{}: {}", id, value).as_ref()).unwrap();
-      assert_eq!(comp.id.name, HttpMessageComponentName::HttpField(inner_name.to_string()));
+      assert_eq!(
+        comp.id.name,
+        HttpMessageComponentName::HttpField(inner_name.to_string())
+      );
       if !id.contains(';') {
         assert_eq!(comp.id.params.0, IndexSet::default());
       } else {
@@ -267,7 +325,8 @@ mod tests {
 
   #[test]
   fn test_from_serialized_string_http_field_params_key() {
-    let comp = HttpMessageComponent::try_from("\"example-header\";key=\"hoge\": example-value").unwrap();
+    let comp =
+      HttpMessageComponent::try_from("\"example-header\";key=\"hoge\": example-value").unwrap();
     assert_eq!(
       comp.id.name,
       HttpMessageComponentName::HttpField("example-header".to_string())
@@ -301,13 +360,19 @@ mod tests {
     let field_values = vec!["application/json".to_owned()];
     let component = build_http_field_component(&id, &field_values).unwrap();
     assert_eq!(component.id, id);
-    assert_eq!(component.value, HttpMessageComponentValue::from("application/json"));
+    assert_eq!(
+      component.value,
+      HttpMessageComponentValue::from("application/json")
+    );
     assert_eq!(component.to_string(), "\"content-type\": application/json");
   }
   #[test]
   fn test_build_http_field_component_multiple_values() {
     let id = HttpMessageComponentId::try_from("\"content-type\"").unwrap();
-    let field_values = vec!["application/json".to_owned(), "application/json-patch+json".to_owned()];
+    let field_values = vec![
+      "application/json".to_owned(),
+      "application/json-patch+json".to_owned(),
+    ];
     let component = build_http_field_component(&id, &field_values).unwrap();
     assert_eq!(component.id, id);
     assert_eq!(
@@ -330,7 +395,9 @@ mod tests {
     assert_eq!(component.id, id);
     assert_eq!(
       component.value,
-      HttpMessageComponentValue::from("application/json;patched=true, application/json-patch+json;patched")
+      HttpMessageComponentValue::from(
+        "application/json;patched=true, application/json-patch+json;patched"
+      )
     );
     assert_eq!(
       component.to_string(),
@@ -344,7 +411,10 @@ mod tests {
     let component = build_http_field_component(&id, &field_values).unwrap();
     assert_eq!(component.id, id);
     assert_eq!(component.value, HttpMessageComponentValue::from("12345678"));
-    assert_eq!(component.to_string(), "\"example-header\";key=\"patched\": 12345678");
+    assert_eq!(
+      component.to_string(),
+      "\"example-header\";key=\"patched\": 12345678"
+    );
   }
   #[test]
   fn test_build_http_field_component_key_multiple_values() {
@@ -356,7 +426,10 @@ mod tests {
     ];
     let component = build_http_field_component(&id, &field_values).unwrap();
     assert_eq!(component.id, id);
-    assert_eq!(component.value, HttpMessageComponentValue::from("12345678, 87654321"));
+    assert_eq!(
+      component.value,
+      HttpMessageComponentValue::from("12345678, 87654321")
+    );
     assert_eq!(
       component.to_string(),
       "\"example-header\";key=\"patched\": 12345678, 87654321"
@@ -376,14 +449,23 @@ mod tests {
     let field_values = vec!["https://example.com/foo".to_owned()];
     let component = build_derived_component(&id, &field_values).unwrap();
     assert_eq!(component.id, id);
-    assert_eq!(component.value, HttpMessageComponentValue::from("https://example.com/foo"));
-    assert_eq!(component.to_string(), "\"@target-uri\": https://example.com/foo");
+    assert_eq!(
+      component.value,
+      HttpMessageComponentValue::from("https://example.com/foo")
+    );
+    assert_eq!(
+      component.to_string(),
+      "\"@target-uri\": https://example.com/foo"
+    );
   }
   #[test]
   fn test_build_http_field_component_query_param() {
     let id = HttpMessageComponentId::try_from("\"@query-param\";name=\"var\"").unwrap();
     let query_param = "var=this%20is%20a%20big%0Amultiline%20value&bar=with+plus+whitespace&fa%C3%A7ade%22%3A%20=something&ok";
-    let field_values = query_param.split('&').map(|v| v.to_owned()).collect::<Vec<_>>();
+    let field_values = query_param
+      .split('&')
+      .map(|v| v.to_owned())
+      .collect::<Vec<_>>();
     let component = build_derived_component(&id, &field_values).unwrap();
     assert_eq!(component.id, id);
     assert_eq!(

--- a/httpsig/src/message_component/component_id.rs
+++ b/httpsig/src/message_component/component_id.rs
@@ -35,18 +35,19 @@ impl TryFrom<&str> for HttpMessageComponentId {
   /// But accept string in the form of `<name>` (without double quotations) when no param is given
   fn try_from(val: &str) -> HttpSigResult<Self> {
     let val = val.trim();
-    let item: sfv::Item = if !val.starts_with('"') && !val.ends_with('"') && !val.is_empty() && !val.contains('"') {
-      // maybe insufficient, but it's enough for now
-      Parser::new(format!("\"{val}\"").as_str())
-        .parse()
-        .map_err(|e| HttpSigError::ParseSFVError(e.to_string()))?
-      // Parser::parse_item(format!("\"{val}\"").as_bytes()).map_err(|e| HttpSigError::ParseSFVError(e.to_string()))?
-    } else {
-      Parser::new(val)
-        .parse()
-        .map_err(|e| HttpSigError::ParseSFVError(e.to_string()))?
-      // Parser::parse_item(val.as_bytes()).map_err(|e| HttpSigError::ParseSFVError(e.to_string()))?
-    };
+    let item: sfv::Item =
+      if !val.starts_with('"') && !val.ends_with('"') && !val.is_empty() && !val.contains('"') {
+        // maybe insufficient, but it's enough for now
+        Parser::new(format!("\"{val}\"").as_str())
+          .parse()
+          .map_err(|e| HttpSigError::ParseSFVError(e.to_string()))?
+        // Parser::parse_item(format!("\"{val}\"").as_bytes()).map_err(|e| HttpSigError::ParseSFVError(e.to_string()))?
+      } else {
+        Parser::new(val)
+          .parse()
+          .map_err(|e| HttpSigError::ParseSFVError(e.to_string()))?
+        // Parser::parse_item(val.as_bytes()).map_err(|e| HttpSigError::ParseSFVError(e.to_string()))?
+      };
 
     let res = Self {
       name: HttpMessageComponentName::try_from(&item.bare_item)?,
@@ -54,8 +55,15 @@ impl TryFrom<&str> for HttpMessageComponentId {
     };
 
     // assert for query param
-    if res.params.0.iter().any(|v| matches!(v, &HttpMessageComponentParam::Name(_)))
-      && !matches!(res.name, HttpMessageComponentName::Derived(DerivedComponentName::QueryParam))
+    if res
+      .params
+      .0
+      .iter()
+      .any(|v| matches!(v, &HttpMessageComponentParam::Name(_)))
+      && !matches!(
+        res.name,
+        HttpMessageComponentName::Derived(DerivedComponentName::QueryParam)
+      )
     {
       return Err(HttpSigError::InvalidComponentId(format!(
         "Invalid http message component id: {res}"

--- a/httpsig/src/message_component/component_param.rs
+++ b/httpsig/src/message_component/component_param.rs
@@ -70,7 +70,11 @@ pub struct HttpMessageComponentParams(pub IndexSet<HttpMessageComponentParam>);
 
 impl std::hash::Hash for HttpMessageComponentParams {
   fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    let mut params = self.0.iter().map(|v| v.clone().into()).collect::<Vec<String>>();
+    let mut params = self
+      .0
+      .iter()
+      .map(|v| v.clone().into())
+      .collect::<Vec<String>>();
     params.sort();
     params.hash(state);
   }
@@ -92,7 +96,12 @@ impl std::fmt::Display for HttpMessageComponentParams {
       write!(
         f,
         ";{}",
-        self.0.iter().map(|v| v.clone().into()).collect::<Vec<String>>().join(";")
+        self
+          .0
+          .iter()
+          .map(|v| v.clone().into())
+          .collect::<Vec<String>>()
+          .join(";")
       )
     } else {
       Ok(())
@@ -107,15 +116,21 @@ pub(super) fn handle_params_sf(field_values: &mut [String]) -> HttpSigResult<()>
     .iter()
     .map(|v| {
       if let Ok(list) = Parser::new(v).parse::<sfv::List>() {
-        list.serialize().ok_or("Failed to serialize structured field value for sf")
+        list
+          .serialize()
+          .ok_or("Failed to serialize structured field value for sf")
       } else if let Ok(dict) = Parser::new(v).parse::<sfv::Dictionary>() {
-        dict.serialize().ok_or("Failed to serialize structured field value for sf")
+        dict
+          .serialize()
+          .ok_or("Failed to serialize structured field value for sf")
       } else {
         Err("invalid structured field value for sf")
       }
     })
     .collect::<Result<Vec<_>, _>>()
-    .map_err(|e| HttpSigError::InvalidComponentParam(format!("Failed to parse structured field value: {e}")))?;
+    .map_err(|e| {
+      HttpSigError::InvalidComponentParam(format!("Failed to parse structured field value: {e}"))
+    })?;
 
   field_values.iter_mut().zip(parsed_list).for_each(|(v, p)| {
     *v = p;
@@ -126,13 +141,18 @@ pub(super) fn handle_params_sf(field_values: &mut [String]) -> HttpSigResult<()>
 
 /* ---------------------------------------------------------------- */
 /// Handle `key` parameter, returns new field values
-pub(super) fn handle_params_key_into(field_values: &[String], key: &str) -> HttpSigResult<Vec<String>> {
+pub(super) fn handle_params_key_into(
+  field_values: &[String],
+  key: &str,
+) -> HttpSigResult<Vec<String>> {
   let dicts = field_values
     .iter()
     .map(|v| Parser::new(v.as_str()).parse() as Result<sfv::Dictionary, _>)
     // Parser::parse_dictionary(v.as_bytes()))
     .collect::<Result<Vec<_>, _>>()
-    .map_err(|e| HttpSigError::InvalidComponentParam(format!("Failed to parse structured field value: {e}")))?;
+    .map_err(|e| {
+      HttpSigError::InvalidComponentParam(format!("Failed to parse structured field value: {e}"))
+    })?;
 
   let found_entries = dicts
     .into_iter()
@@ -144,7 +164,9 @@ pub(super) fn handle_params_key_into(field_values: &[String], key: &str) -> Http
       })
     })
     .collect::<Option<Vec<_>>>()
-    .ok_or_else(|| HttpSigError::InvalidComponentParam(format!("Failed to serialize structured field value")))?;
+    .ok_or_else(|| {
+      HttpSigError::InvalidComponentParam(format!("Failed to serialize structured field value"))
+    })?;
 
   Ok(found_entries)
 }
@@ -165,11 +187,16 @@ mod tests {
     // Parsing structured field value of List type.
     let list_header_input = "  1; a=tok, (\"foo\"   \"bar\" );baz, (  )";
     let list = Parser::new(list_header_input).parse::<sfv::List>().unwrap();
-    assert_eq!(list.serialize().unwrap(), "1;a=tok, (\"foo\" \"bar\");baz, ()");
+    assert_eq!(
+      list.serialize().unwrap(),
+      "1;a=tok, (\"foo\" \"bar\");baz, ()"
+    );
 
     // Parsing structured field value of Dictionary type.
     let dict_header_input = "a=?0, b, c; foo=bar, rating=1.5, fruits=(apple pear), d";
-    let dict = Parser::new(dict_header_input).parse::<sfv::Dictionary>().unwrap();
+    let dict = Parser::new(dict_header_input)
+      .parse::<sfv::Dictionary>()
+      .unwrap();
     assert_eq!(
       dict.serialize().unwrap(),
       "a=?0, b, c;foo=bar, rating=1.5, fruits=(apple pear), d"

--- a/httpsig/src/signature_base.rs
+++ b/httpsig/src/signature_base.rs
@@ -29,7 +29,10 @@ pub struct HttpSignatureHeaders {
 
 impl HttpSignatureHeaders {
   /// Generates (possibly multiple) HttpSignatureHeaders from signature and signature-input header values
-  pub fn try_parse(signature_header: &str, signature_input_header: &str) -> HttpSigResult<HttpSignatureHeadersMap> {
+  pub fn try_parse(
+    signature_header: &str,
+    signature_input_header: &str,
+  ) -> HttpSigResult<HttpSignatureHeadersMap> {
     let signature_input: sfv::Dictionary = Parser::new(signature_input_header)
       .parse()
       .map_err(|e| HttpSigError::ParseSFVError(e.to_string()))?;
@@ -65,7 +68,10 @@ impl HttpSignatureHeaders {
         "The signature header is not a dictionary".to_string(),
       ));
     }
-    if !signature_input.values().all(|v| matches!(v, ListEntry::InnerList(_))) {
+    if !signature_input
+      .values()
+      .all(|v| matches!(v, ListEntry::InnerList(_)))
+    {
       return Err(HttpSigError::BuildSignatureHeaderError(
         "The signature-input header is not a dictionary".to_string(),
       ));
@@ -148,7 +154,10 @@ impl HttpSignatureBase {
   /// This should not be exposed to user and not used directly.
   /// Use wrapper functions generating SignatureBase from base HTTP request and Signer itself instead when newly generating signature
   /// When verifying signature, use wrapper functions generating SignatureBase from HTTP request containing signature params itself instead.
-  pub fn try_new(component_lines: &[HttpMessageComponent], signature_params: &HttpSignatureParams) -> HttpSigResult<Self> {
+  pub fn try_new(
+    component_lines: &[HttpMessageComponent],
+    signature_params: &HttpSignatureParams,
+  ) -> HttpSigResult<Self> {
     // check if the order of component lines is the same as the order of covered message component ids
     if component_lines.len() != signature_params.covered_components.len() {
       return Err(HttpSigError::BuildSignatureBaseError(
@@ -261,9 +270,11 @@ mod test {
   /// こんな感じでSignatureBaseをParamsとかComponentLinesから直接作るのは避ける。
   #[test]
   fn test_signature_base_directly_instantiated() {
-    const SIGPARA: &str = r##";created=1704972031;alg="ed25519";keyid="gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=""##;
+    const SIGPARA: &str =
+      r##";created=1704972031;alg="ed25519";keyid="gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=""##;
     let values = (r##""@method" "@path" "date" "content-digest""##, SIGPARA);
-    let signature_params = HttpSignatureParams::try_from(format!("({}){}", values.0, values.1).as_str()).unwrap();
+    let signature_params =
+      HttpSignatureParams::try_from(format!("({}){}", values.0, values.1).as_str()).unwrap();
 
     let component_lines = COMPONENT_LINES
       .iter()

--- a/httpsig/src/signature_params.rs
+++ b/httpsig/src/signature_params.rs
@@ -36,7 +36,10 @@ pub struct HttpSignatureParams {
 impl HttpSignatureParams {
   /// Create new HttpSignatureParams object for the given covered components only with `created`` current timestamp.
   pub fn try_new(covered_components: &[HttpMessageComponentId]) -> HttpSigResult<Self> {
-    let created = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+    let created = SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .unwrap()
+      .as_secs();
     if !has_unique_elements(covered_components.iter()) {
       return Err(HttpSigError::InvalidSignatureParams(
         "duplicate covered component ids".to_string(),
@@ -113,7 +116,11 @@ impl HttpSignatureParams {
   /// If `exp` field is not present, it always returns false.
   pub fn is_expired(&self) -> bool {
     if let Some(exp) = self.expires {
-      exp < SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()
+      exp
+        < SystemTime::now()
+          .duration_since(UNIX_EPOCH)
+          .unwrap()
+          .as_secs()
     } else {
       false
     }
@@ -122,13 +129,16 @@ impl HttpSignatureParams {
 
 impl std::fmt::Display for HttpSignatureParams {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    let joined = self.covered_components.iter().fold("".to_string(), |acc, v| {
-      if acc.is_empty() {
-        v.to_string()
-      } else {
-        format!("{acc} {v}")
-      }
-    });
+    let joined = self
+      .covered_components
+      .iter()
+      .fold("".to_string(), |acc, v| {
+        if acc.is_empty() {
+          v.to_string()
+        } else {
+          format!("{acc} {v}")
+        }
+      });
     let mut s: String = format!("({})", joined);
     if self.created.is_some() {
       s.push_str(&format!(";created={}", self.created.unwrap()));
@@ -157,7 +167,9 @@ impl TryFrom<&ListEntry> for HttpSignatureParams {
   /// Convert from ListEntry to HttpSignatureParams
   fn try_from(value: &ListEntry) -> HttpSigResult<Self> {
     if !matches!(value, ListEntry::InnerList(_)) {
-      return Err(HttpSigError::InvalidSignatureParams("Invalid signature params".to_string()));
+      return Err(HttpSigError::InvalidSignatureParams(
+        "Invalid signature params".to_string(),
+      ));
     }
     let inner_list_with_params = match value {
       ListEntry::InnerList(v) => v,
@@ -217,7 +229,9 @@ impl TryFrom<&str> for HttpSignatureParams {
       .map_err(|e| HttpSigError::ParseSFVError(e.to_string()))?;
     // let sfv_parsed = Parser::parse_list(value.as_bytes()).map_err(|e| HttpSigError::ParseSFVError(e.to_string()))?;
     if sfv_parsed.len() != 1 || !matches!(sfv_parsed[0], ListEntry::InnerList(_)) {
-      return Err(HttpSigError::InvalidSignatureParams("Invalid signature params".to_string()));
+      return Err(HttpSigError::InvalidSignatureParams(
+        "Invalid signature params".to_string(),
+      ));
     }
     HttpSignatureParams::try_from(&sfv_parsed[0])
   }
@@ -286,7 +300,8 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
 
   #[test]
   fn test_from_string_signature_params_without_param() {
-    let value = r##"("@method" "@path" "@scheme" "@authority" "content-type" "date" "content-length")"##;
+    let value =
+      r##"("@method" "@path" "@scheme" "@authority" "content-type" "date" "content-length")"##;
     let params = HttpSignatureParams::try_from(value);
     assert!(params.is_ok());
     let params = params.unwrap();
@@ -301,7 +316,8 @@ MCowBQYDK2VwAyEA1ixMQcxO46PLlgQfYS46ivFd+n0CcDHSKUnuhm3i1O0=
 
   #[test]
   fn test_from_string_signature_params() {
-    const SIGPARA: &str = r##";created=1704972031;alg="ed25519";keyid="gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=""##;
+    const SIGPARA: &str =
+      r##";created=1704972031;alg="ed25519";keyid="gjrE7ACMxgzYfFHgabgf4kLTg1eKIdsJ94AiFTFj1is=""##;
     let values = vec![
       (
         r##""@method" "@path" "@scheme";req "@authority" "content-type";bs "date" "content-length""##,


### PR DESCRIPTION
This PR adds editor and rustfmt configuration with 2-space indentation in the first commit and reformats the project with rustfmt 1.9.0-stable (59807616e1 2026-04-14) in another commit.

@junkurihara , would you prefer to change indentation size to 4 spaces to align with the ecosystem defaults?