### PR TITLE
fix: build without default features compiles

### DIFF
--- a/httpsig-hyper/src/lib.rs
+++ b/httpsig-hyper/src/lib.rs
@@ -58,9 +58,9 @@ impl std::str::FromStr for ContentDigestType {
 pub use error::{HyperDigestError, HyperDigestResult, HyperSigError, HyperSigResult};
 pub use httpsig::prelude;
 pub use hyper_content_digest::{ContentDigest, RequestContentDigest, ResponseContentDigest};
-pub use hyper_http::{
-  MessageSignature, MessageSignatureReq, MessageSignatureReqSync, MessageSignatureRes, MessageSignatureResSync,
-};
+pub use hyper_http::{MessageSignature, MessageSignatureReq, MessageSignatureRes};
+#[cfg(feature = "blocking")]
+pub use hyper_http::{MessageSignatureReqSync, MessageSignatureResSync};
 
 /* ----------------------------------------------------------------- */
 #[cfg(test)]


### PR DESCRIPTION
This PR fixes the build without default features by not exporting`*Sync` items:

```sh
cargo build --no-default-features
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
```